### PR TITLE
Implement monthly targets and granular admin controls

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -29,6 +29,9 @@ class Company(CompanyBase):
 class GroupBase(BaseModel):
     name: str
     is_admin: bool = False
+    can_manage_users: bool = False
+    can_manage_vacations: bool = False
+    can_approve_manual_entries: bool = False
 
 
 class GroupCreate(GroupBase):
@@ -44,8 +47,15 @@ class UserBase(BaseModel):
     username: str
     full_name: str
     email: EmailStr
-    standard_daily_minutes: int = 480
+    standard_weekly_hours: float = 40.0
     group_id: Optional[int] = None
+
+    @field_validator("standard_weekly_hours")
+    @classmethod
+    def validate_weekly_hours(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("Wochenarbeitszeit darf nicht negativ sein")
+        return value
 
 
 class UserCreate(UserBase):
@@ -75,6 +85,7 @@ class User(UserBase):
     pin_code: str
     group: Optional[Group]
     model_config = ConfigDict(from_attributes=True)
+    standard_daily_minutes: int = 0
 
 
 class TimeEntryBase(BaseModel):

--- a/static/styles.css
+++ b/static/styles.css
@@ -497,6 +497,28 @@ tr.status-rejected td {
     cursor: not-allowed;
 }
 
+.punch-order {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    align-items: flex-end;
+}
+
+.punch-order label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-weight: 600;
+}
+
+.punch-order select {
+    padding: 0.6rem;
+    border-radius: 6px;
+    border: 1px solid #ccd4f3;
+    font: inherit;
+}
+
 .punch-start {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/templates/admin/_nav.html
+++ b/templates/admin/_nav.html
@@ -1,7 +1,17 @@
 <nav class="admin-nav">
-    <a href="/admin/users" class="admin-nav__link {% if admin_active == 'users' %}active{% endif %}">Benutzer</a>
-    <a href="/admin/groups" class="admin-nav__link {% if admin_active == 'groups' %}active{% endif %}">Gruppen</a>
-    <a href="/admin/companies" class="admin-nav__link {% if admin_active == 'companies' %}active{% endif %}">Firmen</a>
-    <a href="/admin/holidays" class="admin-nav__link {% if admin_active == 'holidays' %}active{% endif %}">Feiertage</a>
-    <a href="/admin/approvals" class="admin-nav__link {% if admin_active == 'approvals' %}active{% endif %}">Freigaben</a>
+    {% if admin_permissions.users %}
+        <a href="/admin/users" class="admin-nav__link {% if admin_active == 'users' %}active{% endif %}">Benutzer</a>
+    {% endif %}
+    {% if admin_permissions.groups %}
+        <a href="/admin/groups" class="admin-nav__link {% if admin_active == 'groups' %}active{% endif %}">Gruppen</a>
+    {% endif %}
+    {% if admin_permissions.companies %}
+        <a href="/admin/companies" class="admin-nav__link {% if admin_active == 'companies' %}active{% endif %}">Firmen</a>
+    {% endif %}
+    {% if admin_permissions.holidays %}
+        <a href="/admin/holidays" class="admin-nav__link {% if admin_active == 'holidays' %}active{% endif %}">Feiertage</a>
+    {% endif %}
+    {% if admin_permissions.approvals %}
+        <a href="/admin/approvals" class="admin-nav__link {% if admin_active == 'approvals' %}active{% endif %}">Freigaben</a>
+    {% endif %}
 </nav>

--- a/templates/admin/approvals.html
+++ b/templates/admin/approvals.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% set admin_active = 'approvals' %}
 {% include "admin/_nav.html" %}
+{% if show_manual_section %}
 <section class="card">
     <h1>Manuelle Zeitbuchungen</h1>
     <p>Pendente Zeitbuchungen müssen bestätigt werden, bevor sie in Auswertungen erscheinen.</p>
@@ -42,6 +43,8 @@
         </table>
     </div>
 </section>
+{% endif %}
+{% if show_vacation_section %}
 <section class="card">
     <h1>Urlaubsanträge</h1>
     <div class="table-scroll">
@@ -74,4 +77,10 @@
         </table>
     </div>
 </section>
+{% endif %}
+{% if not show_manual_section and not show_vacation_section %}
+<section class="card">
+    <p>Sie verfügen über keine Freigaberechte.</p>
+</section>
+{% endif %}
 {% endblock %}

--- a/templates/admin/companies.html
+++ b/templates/admin/companies.html
@@ -5,7 +5,8 @@
 {% include "admin/_nav.html" %}
 <section class="card">
     <div class="card-header">
-        <h1>Firmen</h1>
+        <h1>Firmenverwaltung</h1>
+        <a href="/admin/companies/new" class="button">Neue Firma anlegen</a>
     </div>
     <div class="table-scroll">
         <table class="striped-table">
@@ -19,16 +20,10 @@
             <tbody>
             {% for company in companies %}
                 <tr>
-                    <td colspan="3">
-                        <form method="post" action="/admin/companies/{{ company.id }}/update" class="user-form">
-                            <input type="text" name="name" value="{{ company.name }}" required>
-                            <input type="text" name="description" value="{{ company.description }}" placeholder="Beschreibung">
-                            <div class="form-actions">
-                                <button type="submit" class="button small">Speichern</button>
-                                <button type="submit" form="delete-company-{{ company.id }}" class="button danger small">Löschen</button>
-                            </div>
-                        </form>
-                        <form id="delete-company-{{ company.id }}" method="post" action="/admin/companies/{{ company.id }}/delete" onsubmit="return confirm('Firma wirklich löschen? Es dürfen keine Buchungen mehr zugeordnet sein.');"></form>
+                    <td>{{ company.name }}</td>
+                    <td>{{ company.description or '-' }}</td>
+                    <td>
+                        <a class="button small" href="/admin/companies/{{ company.id }}">Bearbeiten</a>
                     </td>
                 </tr>
             {% else %}
@@ -37,13 +32,5 @@
             </tbody>
         </table>
     </div>
-</section>
-<section class="card">
-    <h2>Neue Firma anlegen</h2>
-    <form method="post" action="/admin/companies/create" class="user-form">
-        <input type="text" name="name" placeholder="Firmenname" required>
-        <input type="text" name="description" placeholder="Beschreibung (optional)">
-        <button type="submit" class="button primary">Firma anlegen</button>
-    </form>
 </section>
 {% endblock %}

--- a/templates/admin/company_form.html
+++ b/templates/admin/company_form.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}{% if company %}Firma bearbeiten{% else %}Firma anlegen{% endif %} – Erfassung{% endblock %}
+{% block content %}
+{% set admin_active = 'companies' %}
+{% include "admin/_nav.html" %}
+{% set is_edit = company is not none %}
+<section class="card">
+    <div class="card-header">
+        <h1>{% if is_edit %}Firma bearbeiten{% else %}Neue Firma anlegen{% endif %}</h1>
+        <a href="/admin/companies" class="button ghost">Zur Übersicht</a>
+    </div>
+    <form method="post" action="{% if is_edit %}/admin/companies/{{ company.id }}/update{% else %}/admin/companies/create{% endif %}" class="form-grid">
+        <label class="full-width">
+            Firmenname
+            <input type="text" name="name" value="{{ company.name if is_edit else '' }}" required>
+        </label>
+        <label class="full-width">
+            Beschreibung
+            <textarea name="description" rows="3" placeholder="Optionale Beschreibung">{{ (company.description if is_edit else '')|trim }}</textarea>
+        </label>
+        <div class="form-actions full-width">
+            <button type="submit" class="button primary">{% if is_edit %}Änderungen speichern{% else %}Firma anlegen{% endif %}</button>
+        </div>
+    </form>
+    {% if is_edit %}
+        <form method="post" action="/admin/companies/{{ company.id }}/delete" class="danger-zone" onsubmit="return confirm('Firma wirklich löschen? Es dürfen keine Buchungen mehr zugeordnet sein.');">
+            <button type="submit" class="button danger small">Firma löschen</button>
+        </form>
+    {% endif %}
+</section>
+{% endblock %}

--- a/templates/admin/group_form.html
+++ b/templates/admin/group_form.html
@@ -18,6 +18,19 @@
             <input type="checkbox" name="is_admin" {% if is_edit and group.is_admin %}checked{% endif %}>
             Administratorrechte
         </label>
+        <label class="checkbox">
+            <input type="checkbox" name="can_manage_users" {% if is_edit and group.can_manage_users %}checked{% endif %}>
+            Benutzerverwaltung
+        </label>
+        <label class="checkbox">
+            <input type="checkbox" name="can_manage_vacations" {% if is_edit and group.can_manage_vacations %}checked{% endif %}>
+            Urlaubsanträge verwalten
+        </label>
+        <label class="checkbox">
+            <input type="checkbox" name="can_approve_manual_entries" {% if is_edit and group.can_approve_manual_entries %}checked{% endif %}>
+            Manuelle Stempelungen freigeben
+        </label>
+        <p class="form-hint full-width">Administratorgruppen erhalten automatisch alle Berechtigungen.</p>
         <div class="form-actions full-width">
             <button type="submit" class="button primary">{% if is_edit %}Änderungen speichern{% else %}Gruppe anlegen{% endif %}</button>
         </div>

--- a/templates/admin/groups_list.html
+++ b/templates/admin/groups_list.html
@@ -13,7 +13,7 @@
             <thead>
             <tr>
                 <th>Name</th>
-                <th>Rolle</th>
+                <th>Berechtigungen</th>
                 <th>Benutzer</th>
                 <th>Aktionen</th>
             </tr>
@@ -22,7 +22,17 @@
             {% for group in groups %}
                 <tr>
                     <td>{{ group.name }}</td>
-                    <td>{{ 'Administrator' if group.is_admin else 'Standard' }}</td>
+                    <td>
+                        {% if group.is_admin %}
+                            Administrator (alle Rechte)
+                        {% else %}
+                            {% set perms = namespace(items=[]) %}
+                            {% if group.can_manage_users %}{% set _ = perms.items.append('Benutzerverwaltung') %}{% endif %}
+                            {% if group.can_manage_vacations %}{% set _ = perms.items.append('Urlaubsverwaltung') %}{% endif %}
+                            {% if group.can_approve_manual_entries %}{% set _ = perms.items.append('Manuelle Buchungen') %}{% endif %}
+                            {{ perms.items|join(', ') if perms.items else 'Keine zusätzlichen Rechte' }}
+                        {% endif %}
+                    </td>
                     <td>{{ group.users|length }}</td>
                     <td>
                         <a class="button small" href="/admin/groups/{{ group.id }}">Bearbeiten</a>

--- a/templates/admin/users_form.html
+++ b/templates/admin/users_form.html
@@ -27,8 +27,8 @@
             <input type="text" name="pin_code" value="{{ form_user.pin_code if is_edit else '' }}" pattern="\d{4}" maxlength="4" required>
         </label>
         <label>
-            Tägliche Sollzeit (Minuten)
-            <input type="number" name="standard_daily_minutes" value="{{ form_user.standard_daily_minutes if is_edit else 480 }}" min="1" step="1" required>
+            Wochenarbeitszeit (Stunden)
+            <input type="number" name="standard_weekly_hours" value="{{ form_user.standard_weekly_hours if is_edit else 40 }}" min="0" step="0.25" required>
         </label>
         <label>
             Gruppe

--- a/templates/admin/users_list.html
+++ b/templates/admin/users_list.html
@@ -15,7 +15,7 @@
                 <th>Name</th>
                 <th>Email</th>
                 <th>Gruppe</th>
-                <th>Standardzeit</th>
+                <th>Wochenarbeitszeit</th>
                 <th>Aktionen</th>
             </tr>
             </thead>
@@ -25,7 +25,7 @@
                     <td>{{ item.full_name }} <small class="muted">({{ item.username }})</small></td>
                     <td>{{ item.email }}</td>
                     <td>{{ item.group.name if item.group else 'ohne Gruppe' }}</td>
-                    <td>{{ item.standard_daily_minutes }} Minuten</td>
+                    <td>{{ item.standard_weekly_hours|round(2) }} Std/Woche</td>
                     <td>
                         <a class="button small" href="/admin/users/{{ item.id }}">Bearbeiten</a>
                     </td>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,18 +9,18 @@
 {% endif %}
 
 <section class="metrics">
-    <h1>Arbeitszeitübersicht</h1>
+    <h1>Arbeitszeitübersicht – {{ metrics_month.strftime('%m/%Y') }}</h1>
     <div class="metric-grid">
         <article>
-            <h2>Arbeitszeit</h2>
+            <h2>Ist-Stunden (Monat)</h2>
             <p>{{ (metrics.total_work_minutes / 60)|round(2) }} Stunden</p>
         </article>
         <article>
-            <h2>Überstunden</h2>
+            <h2>Überstunden (Monat)</h2>
             <p>{{ (metrics.total_overtime_minutes / 60)|round(2) }} Stunden</p>
         </article>
         <article>
-            <h2>Sollstunden</h2>
+            <h2>Sollstunden (Monat)</h2>
             <p>{{ (metrics.target_minutes / 60)|round(2) }} Stunden</p>
         </article>
         <article>
@@ -64,12 +64,36 @@
                 <input type="hidden" name="action" value="end_break">
                 <button type="submit" class="button ghost" {% if not active_entry.break_started_at %}disabled{% endif %}>Pause beenden</button>
             </form>
+            {% if active_entry.company_id is not none %}
+                <form method="post" action="/punch">
+                    <input type="hidden" name="next_url" value="/dashboard">
+                    <input type="hidden" name="action" value="end_company">
+                    <button type="submit" class="button">Auftrag beenden</button>
+                </form>
+            {% endif %}
             <form method="post" action="/punch">
                 <input type="hidden" name="next_url" value="/dashboard">
                 <input type="hidden" name="action" value="end_work">
                 <button type="submit" class="button danger">Arbeitszeit beenden</button>
             </form>
         </div>
+        {% if companies %}
+        <form method="post" action="/punch" class="punch-order">
+            <input type="hidden" name="next_url" value="/dashboard">
+            <div class="punch-order-fields">
+                <label>
+                    Auftrag starten
+                    <select name="company_id" required>
+                        <option value="" disabled selected>Firma wählen</option>
+                        {% for company in companies %}
+                            <option value="{{ company.id }}">{{ company.name }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+            </div>
+            <button type="submit" name="action" value="start_company" class="button">Auftrag starten</button>
+        </form>
+        {% endif %}
     {% else %}
         <form method="post" action="/punch" class="punch-start">
             <input type="hidden" name="next_url" value="/dashboard">

--- a/templates/records.html
+++ b/templates/records.html
@@ -14,7 +14,7 @@
 {% endif %}
 <section class="card">
     <div class="card-header">
-        <h1>Arbeitszeitübersicht</h1>
+        <h1>Arbeitszeitübersicht – {{ selected_month.strftime('%m/%Y') }}</h1>
         <a class="button" href="/api/users/{{ user.id }}/excel">Excel-Export</a>
     </div>
     <form method="get" action="/records" class="filter-bar">
@@ -40,19 +40,19 @@
     </form>
     <div class="metric-grid">
         <article>
-            <h2>Ist-Stunden</h2>
+            <h2>Ist-Stunden (Monat)</h2>
             <p>{{ (total_work_minutes / 60)|round(2) }} Stunden</p>
         </article>
         <article>
-            <h2>Soll-Stunden</h2>
+            <h2>Soll-Stunden (Monat)</h2>
             <p>{{ (target_minutes / 60)|round(2) }} Stunden</p>
         </article>
         <article>
-            <h2>Überstunden</h2>
+            <h2>Überstunden (Monat)</h2>
             <p>{{ (total_overtime_minutes / 60)|round(2) }} Stunden</p>
         </article>
     </div>
-    <p class="form-hint">Es werden nur freigegebene Buchungen in der Auswertung berücksichtigt.</p>
+    <p class="form-hint">Kennzahlen beziehen sich immer auf den gesamten Monat und berücksichtigen nur freigegebene Buchungen.</p>
 </section>
 
 <section class="card" id="entries-section">


### PR DESCRIPTION
## Summary
- store weekly working hours for users, compute monthly targets, and reflect the new totals on the dashboard and records view
- introduce granular group permissions with conditional admin navigation and approvals access
- rework the company administration screens and allow managing orders during active work sessions from the dashboard

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e6073f73b8832d8f1afb0c1997798a