### PR TITLE
Add optional time account and overtime vacation handling

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -44,6 +44,8 @@ class User(Base):
     standard_weekly_hours = Column(Float, default=40.0)
     pin_code = Column(String(4), unique=True, nullable=False)
     group_id = Column(Integer, ForeignKey("groups.id"))
+    time_account_enabled = Column(Boolean, default=False)
+    overtime_vacation_enabled = Column(Boolean, default=False)
 
     group = relationship("Group", back_populates="users")
     time_entries = relationship("TimeEntry", back_populates="user", cascade="all, delete-orphan")
@@ -168,6 +170,8 @@ class VacationRequest(Base):
     status = Column(String, default=VacationStatus.PENDING)
     comment = Column(String, default="")
     created_at = Column(DateTime, default=datetime.utcnow)
+    use_overtime = Column(Boolean, default=False)
+    overtime_minutes = Column(Integer, default=0)
 
     user = relationship("User", back_populates="vacation_requests")
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -49,6 +49,8 @@ class UserBase(BaseModel):
     email: EmailStr
     standard_weekly_hours: float = 40.0
     group_id: Optional[int] = None
+    time_account_enabled: bool = False
+    overtime_vacation_enabled: bool = False
 
     @field_validator("standard_weekly_hours")
     @classmethod
@@ -121,15 +123,17 @@ class VacationRequestBase(BaseModel):
     start_date: date
     end_date: date
     comment: str = ""
+    use_overtime: bool = False
 
 
 class VacationRequestCreate(VacationRequestBase):
-    pass
+    overtime_minutes: int = 0
 
 
 class VacationRequest(VacationRequestBase):
     id: int
     status: str
+    overtime_minutes: int
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -151,6 +155,8 @@ class Holiday(HolidayBase):
 class DashboardMetrics(BaseModel):
     total_work_minutes: int
     total_overtime_minutes: int
+    total_undertime_minutes: int
     target_minutes: int
+    overtime_taken_minutes: int
     pending_vacations: int
     upcoming_holidays: List[Holiday]

--- a/app/services.py
+++ b/app/services.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from calendar import monthrange
-from datetime import date
+from datetime import date, timedelta
 
 from sqlalchemy.orm import Session
 
@@ -30,6 +30,45 @@ def calculate_monthly_target_minutes(user: models.User | None, year: int, month:
     return int(round(workdays * daily_minutes))
 
 
+def calculate_required_vacation_minutes(
+    user: models.User | None, start: date, end: date
+) -> int:
+    if not user:
+        return 0
+    daily_minutes = int(round(user.daily_target_minutes or 0))
+    if daily_minutes <= 0:
+        return 0
+    current = start
+    total = 0
+    while current <= end:
+        if current.weekday() < 5:
+            total += daily_minutes
+        current += timedelta(days=1)
+    return total
+
+
+def calculate_vacation_overtime_in_range(
+    user: models.User | None,
+    vacations: list[models.VacationRequest],
+    start: date,
+    end: date,
+) -> int:
+    if not user or not vacations:
+        return 0
+    total = 0
+    for vacation in vacations:
+        if not vacation.use_overtime:
+            continue
+        if vacation.status != models.VacationStatus.APPROVED:
+            continue
+        overlap_start = max(start, vacation.start_date)
+        overlap_end = min(end, vacation.end_date)
+        if overlap_start > overlap_end:
+            continue
+        total += calculate_required_vacation_minutes(user, overlap_start, overlap_end)
+    return total
+
+
 def calculate_dashboard_metrics(
     db: Session, user_id: int, reference_date: date | None = None
 ) -> schemas.DashboardMetrics:
@@ -45,8 +84,16 @@ def calculate_dashboard_metrics(
     )
     user = crud.get_user(db, user_id)
     total_work = sum(entry.worked_minutes for entry in entries)
+    vacations = crud.get_vacations_for_user(db, user_id)
+    overtime_taken = calculate_vacation_overtime_in_range(user, vacations, month_start, month_end)
     target_minutes = calculate_monthly_target_minutes(user, reference.year, reference.month)
-    total_overtime = total_work - target_minutes
+    effective_minutes = total_work + overtime_taken
+    balance = effective_minutes - target_minutes
+    total_overtime = max(balance, 0)
+    total_undertime = max(-balance, 0) if user and user.time_account_enabled else 0
+    if not (user and user.time_account_enabled):
+        total_undertime = 0
+        total_overtime = max(balance, 0)
     pending_vacations = (
         db.query(models.VacationRequest)
         .filter(models.VacationRequest.user_id == user_id)
@@ -58,7 +105,9 @@ def calculate_dashboard_metrics(
     return schemas.DashboardMetrics(
         total_work_minutes=total_work,
         total_overtime_minutes=total_overtime,
+        total_undertime_minutes=total_undertime,
         target_minutes=target_minutes,
+        overtime_taken_minutes=overtime_taken,
         pending_vacations=pending_vacations,
         upcoming_holidays=upcoming_holidays,
     )

--- a/templates/admin/approvals.html
+++ b/templates/admin/approvals.html
@@ -27,7 +27,7 @@
                     <td>{{ entry.work_date.strftime('%d.%m.%Y') }}</td>
                     <td>{{ entry.start_time.strftime('%H:%M') }} – {{ entry.end_time.strftime('%H:%M') }}</td>
                     <td>{{ entry.company.name if entry.company else 'Allgemein' }}</td>
-                    <td>{{ entry.total_break_minutes }} Min</td>
+                    <td>{{ entry.total_break_minutes|format_minutes }} Std</td>
                     <td>{{ entry.notes or '-' }}</td>
                     <td class="actions">
                         <form method="post" action="/admin/time-entries/{{ entry.id }}/status" class="inline-form">
@@ -53,6 +53,7 @@
             <tr>
                 <th>Mitarbeiter</th>
                 <th>Zeitraum</th>
+                <th>Überstundenabbau</th>
                 <th>Kommentar</th>
                 <th>Aktionen</th>
             </tr>
@@ -62,6 +63,7 @@
                 <tr>
                     <td>{{ vacation.user.full_name }}</td>
                     <td>{{ vacation.start_date.strftime('%d.%m.%Y') }} – {{ vacation.end_date.strftime('%d.%m.%Y') }}</td>
+                    <td>{% if vacation.use_overtime %}{{ vacation.overtime_minutes|format_minutes }} Std{% else %}–{% endif %}</td>
                     <td>{{ vacation.comment or '-' }}</td>
                     <td class="actions">
                         <form method="post" action="/admin/vacations/{{ vacation.id }}/status" class="inline-form">
@@ -71,7 +73,7 @@
                     </td>
                 </tr>
             {% else %}
-                <tr><td colspan="4">Keine offenen Urlaubsanträge vorhanden.</td></tr>
+                <tr><td colspan="5">Keine offenen Urlaubsanträge vorhanden.</td></tr>
             {% endfor %}
             </tbody>
         </table>

--- a/templates/admin/users_form.html
+++ b/templates/admin/users_form.html
@@ -39,6 +39,14 @@
                 {% endfor %}
             </select>
         </label>
+        <label class="checkbox">
+            <input type="checkbox" name="time_account_enabled" {% if is_edit and form_user.time_account_enabled %}checked{% endif %}>
+            Zeitkonto aktivieren (Über- und Minusstunden anzeigen)
+        </label>
+        <label class="checkbox">
+            <input type="checkbox" name="overtime_vacation_enabled" {% if is_edit and form_user.overtime_vacation_enabled %}checked{% endif %}>
+            Überstundenabbau über Urlaubsanträge erlauben (Zeitkonto erforderlich)
+        </label>
         <div class="form-actions full-width">
             <button type="submit" class="button primary">{% if is_edit %}Änderungen speichern{% else %}Benutzer anlegen{% endif %}</button>
         </div>

--- a/templates/admin/users_list.html
+++ b/templates/admin/users_list.html
@@ -16,6 +16,8 @@
                 <th>Email</th>
                 <th>Gruppe</th>
                 <th>Wochenarbeitszeit</th>
+                <th>Zeitkonto</th>
+                <th>Überstundenabbau</th>
                 <th>Aktionen</th>
             </tr>
             </thead>
@@ -26,12 +28,14 @@
                     <td>{{ item.email }}</td>
                     <td>{{ item.group.name if item.group else 'ohne Gruppe' }}</td>
                     <td>{{ item.standard_weekly_hours|round(2) }} Std/Woche</td>
+                    <td>{{ 'Aktiv' if item.time_account_enabled else 'Aus' }}</td>
+                    <td>{{ 'Erlaubt' if item.overtime_vacation_enabled else 'Aus' }}</td>
                     <td>
                         <a class="button small" href="/admin/users/{{ item.id }}">Bearbeiten</a>
                     </td>
                 </tr>
             {% else %}
-                <tr><td colspan="5">Es sind noch keine Benutzer vorhanden.</td></tr>
+                <tr><td colspan="7">Es sind noch keine Benutzer vorhanden.</td></tr>
             {% endfor %}
             </tbody>
         </table>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,16 +13,26 @@
     <div class="metric-grid">
         <article>
             <h2>Ist-Stunden (Monat)</h2>
-            <p>{{ (metrics.total_work_minutes / 60)|round(2) }} Stunden</p>
+            <p>{{ metrics.total_work_minutes|format_minutes }} Stunden</p>
         </article>
         <article>
             <h2>Überstunden (Monat)</h2>
-            <p>{{ (metrics.total_overtime_minutes / 60)|round(2) }} Stunden</p>
+            <p>{{ metrics.total_overtime_minutes|format_minutes }} Stunden</p>
         </article>
         <article>
             <h2>Sollstunden (Monat)</h2>
-            <p>{{ (metrics.target_minutes / 60)|round(2) }} Stunden</p>
+            <p>{{ metrics.target_minutes|format_minutes }} Stunden</p>
         </article>
+        <article>
+            <h2>Überstundenabbau</h2>
+            <p>{{ metrics.overtime_taken_minutes|format_minutes }} Stunden</p>
+        </article>
+        {% if user.time_account_enabled %}
+            <article>
+                <h2>Minusstunden (Monat)</h2>
+                <p>{{ metrics.total_undertime_minutes|format_minutes }} Stunden</p>
+            </article>
+        {% endif %}
         <article>
             <h2>Offene Urlaubsanträge</h2>
             <p>{{ metrics.pending_vacations }}</p>
@@ -42,14 +52,14 @@
                 {% if active_entry.company %}
                     <p class="status-line">Firma: {{ active_entry.company.name }}</p>
                 {% endif %}
-                <p class="status-line">Aktuelle Arbeitszeit: {{ (active_entry.worked_minutes / 60)|round(2) }} Stunden</p>
+                <p class="status-line">Aktuelle Arbeitszeit: {{ active_entry.worked_minutes|format_minutes }} Stunden</p>
                 {% if active_entry.break_started_at %}
                     <p class="status-line">
                         <span class="status-badge break">Pause</span>
                         seit {{ active_entry.break_started_at.strftime('%H:%M') }} Uhr
                     </p>
                 {% else %}
-                    <p class="status-line">Erfasste Pausen: {{ active_entry.total_break_minutes }} Minuten</p>
+                    <p class="status-line">Erfasste Pausen: {{ active_entry.total_break_minutes|format_minutes }} Std</p>
                 {% endif %}
             </div>
         </div>

--- a/templates/records.html
+++ b/templates/records.html
@@ -41,16 +41,26 @@
     <div class="metric-grid">
         <article>
             <h2>Ist-Stunden (Monat)</h2>
-            <p>{{ (total_work_minutes / 60)|round(2) }} Stunden</p>
+            <p>{{ total_work_minutes|format_minutes }} Stunden</p>
+        </article>
+        <article>
+            <h2>Überstundenabbau</h2>
+            <p>{{ overtime_taken_minutes|format_minutes }} Stunden</p>
         </article>
         <article>
             <h2>Soll-Stunden (Monat)</h2>
-            <p>{{ (target_minutes / 60)|round(2) }} Stunden</p>
+            <p>{{ target_minutes|format_minutes }} Stunden</p>
         </article>
         <article>
             <h2>Überstunden (Monat)</h2>
-            <p>{{ (total_overtime_minutes / 60)|round(2) }} Stunden</p>
+            <p>{{ total_overtime_minutes|format_minutes }} Stunden</p>
         </article>
+        {% if user.time_account_enabled %}
+            <article>
+                <h2>Minusstunden (Monat)</h2>
+                <p>{{ total_undertime_minutes|format_minutes }} Stunden</p>
+            </article>
+        {% endif %}
     </div>
     <p class="form-hint">Kennzahlen beziehen sich immer auf den gesamten Monat und berücksichtigen nur freigegebene Buchungen.</p>
 </section>
@@ -80,12 +90,12 @@
                     <td>{{ entry.start_time.strftime('%H:%M') }}</td>
                     <td>{{ entry.end_time.strftime('%H:%M') }}</td>
                     <td>
-                        {{ entry.total_break_minutes }} Min
+                        {{ entry.total_break_minutes|format_minutes }} Std
                         {% if entry.required_break_minutes > entry.total_break_minutes %}
-                            ({{ entry.required_break_minutes }} Min erforderlich)
+                            ({{ entry.required_break_minutes|format_minutes }} Std erforderlich)
                         {% endif %}
                     </td>
-                    <td>{{ (entry.worked_minutes / 60)|round(2) }} Std</td>
+                    <td>{{ entry.worked_minutes|format_minutes }} Std</td>
                     <td class="status-label status-{{ entry.status }}">
                         {% if entry.status == 'approved' %}Freigegeben{% elif entry.status == 'pending' %}Wartet auf Freigabe{% else %}Abgelehnt{% endif %}
                     </td>
@@ -117,7 +127,7 @@
                 <tr>
                     <td>{{ row.name }}</td>
                     <td>{{ row.count }}</td>
-                    <td>{{ (row.minutes / 60)|round(2) }} Std</td>
+                    <td>{{ row.minutes|format_minutes }} Std</td>
                 </tr>
             {% else %}
                 <tr><td colspan="3">Keine freigegebenen Buchungen im Filter.</td></tr>
@@ -142,7 +152,7 @@
                     <tr>
                         <td>{{ row.name }}</td>
                         <td>{{ row.count }}</td>
-                        <td>{{ (row.minutes / 60)|round(2) }} Std</td>
+                        <td>{{ row.minutes|format_minutes }} Std</td>
                     </tr>
                 {% endfor %}
                 </tbody>
@@ -169,6 +179,12 @@
             Kommentar
             <textarea name="comment" rows="2" placeholder="Optionaler Hinweis"></textarea>
         </label>
+        {% if user.overtime_vacation_enabled %}
+            <label class="checkbox full-width">
+                <input type="checkbox" name="use_overtime">
+                Überstunden für diesen Antrag einsetzen ({{ user.daily_target_minutes|format_minutes }} Std pro Arbeitstag)
+            </label>
+        {% endif %}
         <div class="form-actions full-width">
             <button type="submit" class="button primary">Urlaubsantrag senden</button>
         </div>
@@ -179,6 +195,7 @@
             <tr>
                 <th>Zeitraum</th>
                 <th>Status</th>
+                <th>Überstundenabbau</th>
                 <th>Kommentar</th>
             </tr>
             </thead>
@@ -189,10 +206,17 @@
                     <td class="status-label status-{{ vacation.status }}">
                         {% if vacation.status == 'approved' %}Genehmigt{% elif vacation.status == 'pending' %}Wartet auf Freigabe{% else %}Abgelehnt{% endif %}
                     </td>
+                    <td>
+                        {% if vacation.use_overtime %}
+                            {{ vacation.overtime_minutes|format_minutes }} Std
+                        {% else %}
+                            –
+                        {% endif %}
+                    </td>
                     <td>{{ vacation.comment or '-' }}</td>
                 </tr>
             {% else %}
-                <tr><td colspan="3">Keine Urlaubsanträge vorhanden.</td></tr>
+                <tr><td colspan="4">Keine Urlaubsanträge vorhanden.</td></tr>
             {% endfor %}
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- add optional time account and overtime-vacation flags on users and persist overtime usage on vacation requests
- calculate overtime, undertime, and overtime usage for dashboards and records while showing durations in hh:mm
- expose the new capabilities in admin and user interfaces, including updated tables, forms, and approvals views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e60c95f8b8832dbcacd4bbcdf31ffd