### PR TITLE
Pruefschluessel beim Aktivieren automatisch uebernehmen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,15 @@ Lizenz anschließend **offline** und hält sich an die lizenzierte Benutzerzahl.
 - **Offline-Prüfung** bei jedem Start und jeder Statusabfrage: Schemaversion,
   Ed25519-Signatur über die kanonische JSON-Form ohne das Feld `signature`,
   Produktkennung, Deployment-ID und Ablaufdatum. Der Lizenzserver muss dafür
-  nicht erreichbar sein. Die öffentlichen Prüfschlüssel liegen in
-  `app/licensing_keys.py`, die `key_id` aus dem Dokument erlaubt Rotation.
+  nicht erreichbar sein.
+- **Prüfschlüssel wird automatisch übernommen.** Bei der ersten Aktivierung
+  holt die Installation den öffentlichen Schlüssel des Lizenzservers
+  (`GET /v1/instance/public-key`) und merkt ihn sich dauerhaft. Danach ist er
+  je `key_id` unveränderlich: Ein gewechselter Schlüssel führt zum Abbruch,
+  ohne etwas zu überschreiben; eine Rotation über eine neue `key_id` wird
+  ergänzt. Ein in `app/licensing_keys.py` eingebetteter Schlüssel hat Vorrang.
+  Auf der Lizenzseite steht ein Fingerprint (`SHA256:…`) zum Abgleich mit dem
+  Lizenzserver.
 - **Durchsetzung**: `max_users` (`0` = unbegrenzt) und Ablaufdatum. Über die
   Oberfläche mit Klartextmeldung, über `POST /api/users` mit **HTTP 402**.
   Bestehende Benutzer werden nie gesperrt oder gelöscht.

--- a/README.md
+++ b/README.md
@@ -399,11 +399,23 @@ Wer ihn gar nicht speichern will, entfernt nach der Aktivierung das Feld
 `activation_key` aus `config/license.json`. Die Lizenz bleibt gültig; nur
 „Erneut prüfen“ verlangt dann wieder eine Eingabe.
 
-### Prüfschlüssel einbetten (für Herausgeber)
+### Prüfschlüssel
 
-Im Lizenzserver-Repository erzeugt `python -m app.cli keygen` ein
-Ed25519-Paar und gibt das **öffentliche** PEM aus; der private Schlüssel
-verlässt den Lizenzserver nie. Das PEM wandert nach `app/licensing_keys.py`:
+Der Lizenzserver signiert das Lizenzdokument mit seinem **privaten** Schlüssel,
+Erfassung prüft es mit dem **öffentlichen**. Dieser wird **automatisch bei der
+ersten Aktivierung übernommen** (`GET /v1/instance/public-key`) – zu kopieren
+ist nichts.
+
+Danach ist er je `key_id` unveränderlich: Weist sich derselbe Server später mit
+einem anderen Schlüssel aus, bricht die Aktivierung ab, ohne etwas zu
+überschreiben. Eine echte Rotation läuft über eine neue `key_id` und wird
+ergänzt.
+
+Auf der Lizenzseite steht ein **Fingerprint** (`SHA256:…`), der auch im
+Lizenzserver unter „Instanz" erscheint. Wer möchte, gleicht ihn ab.
+
+Wer den Schlüssel fest verdrahten will – dann ist auch der erste Kontakt
+abgesichert –, trägt das PEM in `app/licensing_keys.py` ein:
 
 ```python
 EMBEDDED_PUBLIC_KEYS = {
@@ -411,13 +423,9 @@ EMBEDDED_PUBLIC_KEYS = {
 }
 ```
 
-Die `key_id` steht in jedem Lizenzdokument; bei einer Rotation bleibt der alte
-Eintrag stehen, bis alle Installationen ein neu signiertes Dokument haben. Für
-Entwicklung und Tests lässt sich die Zuordnung über die Umgebungsvariable
-`ERFASSUNG_LICENSE_PUBLIC_KEYS` (JSON `{"key_id": "<PEM>"}`) überschreiben.
-
-Ohne eingebetteten Prüfschlüssel läuft die Anwendung dauerhaft als „nicht
-lizenziert“; die Lizenzseite weist darauf hin.
+Ein so eingebetteter Schlüssel hat Vorrang. Für Entwicklung und Tests lässt
+sich die Zuordnung über `ERFASSUNG_LICENSE_PUBLIC_KEYS` (JSON
+`{"key_id": "<PEM>"}`) überschreiben.
 
 ### Grenze des Kopierschutzes
 

--- a/app/licensing.py
+++ b/app/licensing.py
@@ -36,6 +36,7 @@ kein vollständiger Kopierschutz und wird auch nicht als solcher dargestellt.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -125,8 +126,8 @@ def _b64u_decode(value: str) -> bytes:
     return base64.urlsafe_b64decode(value + padding)
 
 
-def public_keys() -> dict[str, str]:
-    """``{key_id: PEM}`` – eingebettet, optional per Umgebung überschrieben."""
+def embedded_public_keys() -> dict[str, str]:
+    """Vom Herausgeber mitgelieferte Schlüssel, optional per Umgebung ersetzt."""
     override = os.environ.get(PUBLIC_KEYS_ENV)
     if override:
         try:
@@ -138,6 +139,27 @@ def public_keys() -> dict[str, str]:
             return {str(k): str(v) for k, v in parsed.items()}
         LOGGER.warning("%s muss ein JSON-Objekt sein – wird ignoriert.", PUBLIC_KEYS_ENV)
     return dict(EMBEDDED_PUBLIC_KEYS)
+
+
+def public_keys(config: Optional["LicenseConfig"] = None) -> dict[str, str]:
+    """Alle Schlüssel, mit denen ein Lizenzdokument geprüft werden darf.
+
+    Eingebettete Schlüssel des Herausgebers haben Vorrang; ergänzt werden die
+    bei der Aktivierung übernommenen Schlüssel des eigenen Lizenzservers.
+    """
+    keys = dict((config or load_config()).trusted_keys)
+    keys.update(embedded_public_keys())
+    return keys
+
+
+def fingerprint(pem: str) -> str:
+    """``SHA256:<vier Gruppen>`` – identisch zum Lizenzserver.
+
+    Damit lässt sich mit bloßem Auge abgleichen, ob diese Installation den
+    richtigen Lizenzserver erwischt hat.
+    """
+    digest = hashlib.sha256(pem.strip().encode("ascii")).hexdigest()
+    return "SHA256:" + ":".join(digest[i : i + 4] for i in range(0, 16, 4)).upper()
 
 
 def _load_public_key(pem: str) -> Optional[Ed25519PublicKey]:
@@ -203,6 +225,9 @@ class LicenseConfig:
     document: dict[str, Any] = field(default_factory=dict)
     activated_at: str = ""
     last_checked_at: str = ""
+    #: ``{key_id: PEM}`` – bei der ersten Aktivierung vom Lizenzserver
+    #: übernommen und danach unveränderlich (siehe :func:`adopt_public_keys`).
+    trusted_keys: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -212,6 +237,7 @@ class LicenseConfig:
             "document": self.document,
             "activated_at": self.activated_at,
             "last_checked_at": self.last_checked_at,
+            "trusted_keys": self.trusted_keys,
         }
 
     @classmethod
@@ -226,6 +252,10 @@ class LicenseConfig:
         config.document = document if isinstance(document, dict) else {}
         config.activated_at = str(payload.get("activated_at") or "")
         config.last_checked_at = str(payload.get("last_checked_at") or "")
+        trusted = payload.get("trusted_keys")
+        config.trusted_keys = (
+            {str(k): str(v) for k, v in trusted.items()} if isinstance(trusted, dict) else {}
+        )
         return config
 
 
@@ -329,6 +359,9 @@ class LicenseStatus:
     last_checked_at: Optional[datetime] = None
     activation_key_masked: str = ""
     users_in_use: int = 0
+    #: Fingerprint des Schlüssels, mit dem geprüft wurde – zum Abgleich mit
+    #: der Instanzseite des Lizenzservers.
+    key_fingerprint: str = ""
 
     @property
     def label(self) -> str:
@@ -387,6 +420,7 @@ class LicenseStatus:
             "expires_at": stamp(self.expires_at),
             "days_until_expiry": self.days_until_expiry,
             "key_id": self.key_id,
+            "key_fingerprint": self.key_fingerprint,
             "deployment_id": self.deployment_id,
             "server_url": self.server_url,
             "activated_at": stamp(self.activated_at),
@@ -426,7 +460,7 @@ def _status_from_document(
             f"unterstützt Version {SUPPORTED_SCHEMA_VERSION}. Bitte die Anwendung aktualisieren."
         )
         return status
-    if not verify_signature(document):
+    if not verify_signature(document, public_keys(config)):
         status.status = STATUS_INVALID
         status.reason = (
             "Die Signatur des Lizenzdokuments ist ungültig oder der Schlüssel ist unbekannt."
@@ -448,6 +482,9 @@ def _status_from_document(
         status.reason = "Die Lizenz ist abgelaufen."
         return status
 
+    pem = public_keys(config).get(status.key_id)
+    if pem:
+        status.key_fingerprint = fingerprint(pem)
     status.status = STATUS_VALID
     return status
 
@@ -561,6 +598,63 @@ def _raise_for_activation(response: httpx.Response) -> None:
     raise LicenseError(f"Unerwartete Antwort des Lizenzservers (HTTP {response.status_code}).")
 
 
+def fetch_public_keys(server_url: str) -> dict[str, str]:
+    """Öffentliche Prüfschlüssel des Lizenzservers abholen.
+
+    Ein öffentlicher Schlüssel ist kein Geheimnis – mit ihm lassen sich
+    Signaturen nur prüfen, nie erzeugen. Der Abruf ist deshalb unauthentifiziert.
+    """
+    url = normalize_server_url(server_url)
+    try:
+        with httpx.Client(timeout=HTTP_TIMEOUT_SECONDS) as client:
+            response = client.get(f"{url}/v1/instance/public-key")
+    except httpx.HTTPError as exc:
+        raise LicenseError(f"Der Lizenzserver ist nicht erreichbar: {exc}") from exc
+    if response.status_code != 200:
+        raise LicenseError(
+            "Der Lizenzserver hat keinen Prüfschlüssel geliefert "
+            f"(HTTP {response.status_code})."
+        )
+    try:
+        payload = response.json()
+        key_id = str(payload["key_id"])
+        pem = str(payload["public_key"])
+    except (ValueError, KeyError, TypeError) as exc:
+        raise LicenseError("Der Lizenzserver hat eine unerwartete Antwort geschickt.") from exc
+    if _load_public_key(pem) is None:
+        raise LicenseError("Der Lizenzserver hat einen unbrauchbaren Prüfschlüssel geliefert.")
+    return {key_id: pem}
+
+
+def adopt_public_keys(config: LicenseConfig, offered: dict[str, str]) -> dict[str, str]:
+    """Angebotene Schlüssel übernehmen – aber niemals einen bestehenden ersetzen.
+
+    Beim ersten Kontakt wird dem Server vertraut (wie bei SSH). Danach ist der
+    Schlüssel je ``key_id`` unveränderlich: Wer sich später mit einem anderen
+    Schlüssel für dieselbe ``key_id`` ausgibt, wird abgewiesen. Ein Angreifer,
+    der den Server austauscht, kann damit keine eigenen Lizenzen unterschieben.
+
+    Eine echte Schlüsselrotation läuft über eine **neue** ``key_id`` – die wird
+    anstandslos ergänzt.
+    """
+    trusted = dict(config.trusted_keys)
+    embedded = embedded_public_keys()
+    for key_id, pem in offered.items():
+        known = trusted.get(key_id) or embedded.get(key_id)
+        if known and known.strip() != pem.strip():
+            raise LicenseError(
+                f"Der Lizenzserver weist sich für „{key_id}“ mit einem anderen "
+                f"Prüfschlüssel aus als bisher (bekannt: {fingerprint(known)}, "
+                f"angeboten: {fingerprint(pem)}). Die Aktivierung wurde "
+                "abgebrochen. Das ist zu erwarten, wenn der Lizenzserver neu "
+                "aufgesetzt wurde – dann bitte die Lizenz hier entfernen und "
+                "neu aktivieren. Andernfalls den Herausgeber kontaktieren."
+            )
+        if not known:
+            trusted[key_id] = pem
+    return trusted
+
+
 def activate(server_url: str, activation_key: str) -> LicenseStatus:
     """Installation aktivieren und das signierte Dokument ablegen.
 
@@ -576,6 +670,11 @@ def activate(server_url: str, activation_key: str) -> LicenseStatus:
     if not config.deployment_id:
         deployment_id()  # erzeugt und speichert die Kennung
         config = load_config()
+
+    # Prüfschlüssel zuerst: Ohne ihn ließe sich das Lizenzdokument gleich
+    # darauf gar nicht prüfen. Ein Wechsel des Schlüssels bricht hier ab,
+    # bevor irgendetwas gespeichert wird.
+    trusted = adopt_public_keys(config, fetch_public_keys(url))
 
     response = _post(
         f"{url}/v1/activations",
@@ -605,6 +704,7 @@ def activate(server_url: str, activation_key: str) -> LicenseStatus:
         document=document,
         activated_at=config.activated_at or _utcnow().isoformat(),
         last_checked_at=_utcnow().isoformat(),
+        trusted_keys=trusted,
     )
     status = _status_from_document(
         document, candidate, expected_deployment=config.deployment_id
@@ -664,6 +764,9 @@ def deactivate() -> None:
         LicenseConfig(
             deployment_id=config.deployment_id,
             server_url=config.server_url,
+            # Übernommene Prüfschlüssel bleiben erhalten: Sie sind kein
+            # Geheimnis, und ein späterer Schlüsselwechsel fällt so weiterhin auf.
+            trusted_keys=config.trusted_keys,
         )
     )
     _log("Lizenz lokal entfernt.")
@@ -683,7 +786,11 @@ __all__ = [
     "count_users",
     "current_status",
     "deactivate",
+    "adopt_public_keys",
     "deployment_id",
+    "embedded_public_keys",
+    "fetch_public_keys",
+    "fingerprint",
     "harden_config_permissions",
     "has_feature",
     "load_config",

--- a/app/main.py
+++ b/app/main.py
@@ -4956,7 +4956,6 @@ def admin_system_license(request: Request, db: Session = Depends(database.get_db
         admin_active="system_license",
         license_status=licensing.current_status(db),
         license_config=licensing.load_config(),
-        license_keys_configured=bool(licensing.public_keys()),
     )
 
 

--- a/docs/RELEASE_NOTES_0.11.0.md
+++ b/docs/RELEASE_NOTES_0.11.0.md
@@ -12,7 +12,7 @@ und hält sich an die lizenzierte Benutzerzahl.
 | Neu | Administration → System → **Lizenz** |
 | Neu | `GET /api/license` (Status als JSON, ohne Geheimnisse) |
 | Neu | Protokollkanal `license.log` |
-| Neu | `config/license.json` (Deployment-ID, Serveradresse, signiertes Dokument) |
+| Neu | `config/license.json` (Deployment-ID, Serveradresse, Dokument, Prüfschlüssel) |
 | Durchgesetzt | Benutzerobergrenze `max_users`, Ablaufdatum |
 | Nicht durchgesetzt | alles Übrige – eine Installation ohne Lizenz läuft weiter |
 | Datenbank | **keine** Schemaänderung, keine Migration nötig |
@@ -42,8 +42,8 @@ frisches Dokument – nötig nach einer Verlängerung oder Erweiterung.
 ### 3. Offline-Prüfung
 
 Bei jedem Start und bei jeder Statusabfrage wird das gespeicherte Dokument
-gegen die in `app/licensing_keys.py` eingebetteten öffentlichen Schlüssel
-geprüft. Der Lizenzserver muss dafür **nicht** erreichbar sein. Geprüft werden:
+gegen die bekannten öffentlichen Schlüssel geprüft. Der Lizenzserver muss dafür
+**nicht** erreichbar sein. Geprüft werden:
 
 1. Version des Dokumentschemas,
 2. Ed25519-Signatur über die kanonische JSON-Form (sortierte Schlüssel, keine
@@ -70,6 +70,33 @@ Benutzer werden nie gesperrt oder gelöscht.
 Optionale Merkmale aus dem Lizenzdokument stehen über
 `licensing.has_feature("name")` bereit und werden auf der Lizenzseite
 angezeigt; in dieser Version hängt noch keine Funktion daran.
+
+## Woher der Prüfschlüssel kommt
+
+Der Lizenzserver signiert das Lizenzdokument mit seinem **privaten** Schlüssel;
+Erfassung prüft die Signatur mit dem **öffentlichen**. Ohne diesen Schlüssel
+könnte sich jeder ein Dokument mit beliebiger Benutzerzahl selbst schreiben.
+
+Er wird **automatisch bei der ersten Aktivierung übernommen** – der Server
+liefert ihn über `GET /v1/instance/public-key`. Kopieren muss niemand etwas.
+Danach gilt:
+
+- Der Schlüssel ist je `key_id` **unveränderlich**. Weist sich derselbe Server
+  später mit einem anderen Schlüssel für dieselbe `key_id` aus, bricht die
+  Aktivierung mit einer klaren Meldung ab und **nichts** wird überschrieben.
+  Ein untergeschobener Lizenzserver kann so keine eigenen Lizenzen einschleusen.
+- Eine echte **Schlüsselrotation** läuft über eine neue `key_id`; die wird
+  anstandslos ergänzt, der alte Schlüssel bleibt erhalten, damit vorhandene
+  Dokumente prüfbar bleiben.
+- Bringt der Herausgeber einen Schlüssel in `app/licensing_keys.py` mit, ist
+  dieser maßgeblich und lässt sich vom Server nicht überstimmen.
+
+Auf beiden Seiten steht ein **Fingerprint** (`SHA256:…`): in Erfassung auf der
+Lizenzseite, im Lizenzserver unter „Instanz". Wer möchte, gleicht ihn einmal
+ab; nötig ist es nicht.
+
+Das Vertrauen beim allerersten Kontakt ist bewusst gewählt (wie bei SSH) und
+als Restrisiko unten aufgeführt.
 
 ## Umgang mit dem Aktivierungsschlüssel
 
@@ -107,20 +134,17 @@ Weitere Restrisiken:
   vergibt kurze Laufzeiten (`expires_at`).
 - **Die Ablaufprüfung nutzt die lokale Uhr** und lässt sich auf dem
   Kundensystem manipulieren.
-- **Ohne eingebetteten Prüfschlüssel** (Auslieferung ohne
-  `EMBEDDED_PUBLIC_KEYS`) läuft die Anwendung dauerhaft im Zustand „nicht
-  lizenziert“. Die Lizenzseite weist darauf hin.
+- **Vertrauen beim ersten Kontakt.** Der Prüfschlüssel wird bei der ersten
+  Aktivierung ungeprüft übernommen. Wer genau in diesem Moment die Verbindung
+  umlenkt, kann einen eigenen Schlüssel unterschieben. Danach ist er
+  unveränderlich und jeder Wechsel fällt auf. Zum Ausschließen: den
+  Fingerprint nach der Aktivierung mit dem Lizenzserver vergleichen.
 
-## Für Herausgeber: Prüfschlüssel einbetten
+## Optional: Prüfschlüssel fest einbetten
 
-Im Lizenzserver-Repository:
-
-```bash
-python -m app.cli keygen --private-out /run/secrets/license_signing_key.pem
-```
-
-Der Befehl gibt das **öffentliche** PEM aus; der private Schlüssel verlässt den
-Lizenzserver nie. Das PEM in `app/licensing_keys.py` eintragen:
+Für den Normalfall nicht nötig – der Schlüssel wird automatisch übernommen.
+Wer ihn fest verdrahten will (dann ist auch der erste Kontakt abgesichert),
+trägt das öffentliche PEM in `app/licensing_keys.py` ein:
 
 ```python
 EMBEDDED_PUBLIC_KEYS = {
@@ -128,9 +152,8 @@ EMBEDDED_PUBLIC_KEYS = {
 }
 ```
 
-Die `key_id` (hier `k1`) steht in jedem Lizenzdokument. Bei einer Rotation
-bleibt der alte Eintrag stehen, bis alle Installationen ein neu signiertes
-Dokument erhalten haben.
+Das PEM zeigt der Lizenzserver unter „Instanz" an. Ein so eingebetteter
+Schlüssel hat Vorrang und lässt sich von einem Server nicht überstimmen.
 
 Für Entwicklung und Tests lässt sich die Zuordnung über die Umgebungsvariable
 `ERFASSUNG_LICENSE_PUBLIC_KEYS` (JSON-Objekt `{"key_id": "<PEM>"}`)
@@ -161,7 +184,7 @@ Für Entwicklung und Tests lässt sich die Zuordnung über die Umgebungsvariable
 
 **Tests**
 
-`tests/test_v0110.py` – 48 Tests: Deployment-ID (Stabilität, Zufall, keine
+`tests/test_v0110.py` – 57 Tests: Deployment-ID (Stabilität, Zufall, keine
 Hostdaten, Dateirechte, Verengung nach einem Restore), Offline-Prüfung (gültig,
 manipuliert, fremder Schlüssel, fremde Installation, fremdes Produkt,
 unbekannte Schemaversion, abgelaufen, Ablauffenster), kanonisches JSON,
@@ -171,3 +194,9 @@ Server, erneute Prüfung, Deaktivierung mit und ohne Server), Durchsetzung
 (unlizenziert, Grenze, `max_users = 0`, abgelaufen, HTML- und API-Anlage),
 Oberfläche (Status, maskierter Schlüssel, Navigation, Balken, Formular,
 Berechtigungen) sowie Protokoll und Export.
+
+Dazu die Schlüsselübernahme: automatische Übernahme beim ersten Kontakt,
+Ablehnung eines gewechselten Schlüssels unter derselben `key_id` (ohne
+irgendetwas zu überschreiben), Ergänzung bei echter Rotation über eine neue
+`key_id`, Vorrang des eingebetteten Schlüssels, Fingerprint-Format und
+-Anzeige sowie Abbruch vor dem Speichern, wenn der Server nicht erreichbar ist.

--- a/templates/admin/system_license.html
+++ b/templates/admin/system_license.html
@@ -24,13 +24,6 @@
         <p class="card-header__hint">{{ state.reason }}</p>
     {% endif %}
 
-    {% if not license_keys_configured %}
-        <div class="alert alert-warning">
-            In dieser Ausgabe ist kein öffentlicher Prüfschlüssel hinterlegt
-            (<code>app/licensing_keys.py</code>). Lizenzdokumente lassen sich deshalb nicht
-            prüfen; die Anwendung läuft unlizenziert weiter.
-        </div>
-    {% endif %}
 
     <div class="metric-grid">
         <article class="metric-tile">
@@ -83,6 +76,10 @@
                 <tr><th>Lizenzserver</th><td>{{ state.server_url or '–' }}</td></tr>
                 <tr><th>Aktivierungsschlüssel</th><td>{{ state.activation_key_masked or '–' }}</td></tr>
                 <tr><th>Signierschlüssel (key_id)</th><td>{{ state.key_id or '–' }}</td></tr>
+                <tr>
+                    <th>Fingerprint</th>
+                    <td class="mono">{{ state.key_fingerprint or '–' }}</td>
+                </tr>
                 <tr><th>Ausgestellt</th><td>{{ state.issued_at.strftime('%d.%m.%Y %H:%M') if state.issued_at else '–' }}</td></tr>
                 <tr><th>Aktiviert am</th><td>{{ state.activated_at.strftime('%d.%m.%Y %H:%M') if state.activated_at else '–' }}</td></tr>
                 <tr><th>Zuletzt geprüft</th><td>{{ state.last_checked_at.strftime('%d.%m.%Y %H:%M') if state.last_checked_at else '–' }}</td></tr>
@@ -93,6 +90,9 @@
         Die Deployment-ID ist eine Zufallszahl ohne Hardware- oder Personenbezug. Sie
         bleibt bei einem Serverumzug erhalten, solange das <code>config</code>-Volume
         mitgenommen wird – die Lizenz muss dann nicht erneut aktiviert werden.
+        Der <strong>Fingerprint</strong> ist derselbe, den der Lizenzserver auf seiner
+        Seite „Instanz“ anzeigt; stimmen beide überein, wurde die Lizenz vom richtigen
+        Server ausgestellt.
         Protokoll unter <a href="/admin/system/logs?channel=license">license.log</a>.
     </p>
 </section>
@@ -116,6 +116,8 @@
                 Wird verschlüsselt übertragen und nur lokal im <code>config</code>-Volume
                 abgelegt, damit die Lizenz ohne erneute Eingabe nachgeprüft werden kann.
                 In Oberfläche und Protokoll erscheint er ausschließlich maskiert.
+                Beim Aktivieren wird der Prüfschlüssel des Servers automatisch übernommen
+                und danach nicht mehr geändert.
             </small>
         </label>
         <div class="form-actions full-width">

--- a/tests/test_v0110.py
+++ b/tests/test_v0110.py
@@ -174,13 +174,29 @@ class _Response:
         return self._payload
 
 
-def _stub_server(licensing, monkeypatch, response: _Response, calls: list | None = None):
+def _stub_server(
+    licensing,
+    monkeypatch,
+    response: _Response,
+    calls: list | None = None,
+    *,
+    public_pem: str | None = None,
+    key_id: str = KEY_ID,
+):
+    """Lizenzserver nachbilden: Prüfschlüssel-Abruf und Aktivierung."""
+
     def fake_post(url: str, payload: dict):
         if calls is not None:
             calls.append((url, payload))
         return response
 
+    def fake_fetch(server_url: str) -> dict:
+        if public_pem is None:
+            raise AssertionError("Test muss public_pem angeben")
+        return {key_id: public_pem}
+
     monkeypatch.setattr(licensing, "_post", fake_post)
+    monkeypatch.setattr(licensing, "fetch_public_keys", fake_fetch)
 
 
 # --- Deployment-ID ---------------------------------------------------------
@@ -326,7 +342,10 @@ def test_activation_stores_the_signed_document(licensing, keypair, monkeypatch):
     deployment = licensing.deployment_id()
     document = _document(private_key, deployment, max_users=3)
     calls: list = []
-    _stub_server(licensing, monkeypatch, _Response(200, {"license": document}), calls)
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}), calls,
+        public_pem=keypair[1],
+    )
 
     state = licensing.activate("lizenz.example.org", " ERF-TEST-KEY-0001 ")
 
@@ -347,7 +366,10 @@ def test_activation_rejects_an_unusable_document_without_storing_it(
     private_key, _ = keypair
     # Dokument für eine fremde Installation – darf nie gespeichert werden.
     document = _document(private_key, "erfassung-" + "1" * 32)
-    _stub_server(licensing, monkeypatch, _Response(200, {"license": document}))
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}),
+        public_pem=keypair[1],
+    )
 
     with pytest.raises(licensing.LicenseError):
         licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
@@ -364,8 +386,10 @@ def test_activation_rejects_an_unusable_document_without_storing_it(
         (500, "HTTP 500"),
     ],
 )
-def test_activation_errors_are_translated(licensing, monkeypatch, status_code, expected):
-    _stub_server(licensing, monkeypatch, _Response(status_code))
+def test_activation_errors_are_translated(
+    licensing, keypair, monkeypatch, status_code, expected
+):
+    _stub_server(licensing, monkeypatch, _Response(status_code), public_pem=keypair[1])
     with pytest.raises(licensing.LicenseError) as excinfo:
         licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
     assert expected in str(excinfo.value)
@@ -399,6 +423,7 @@ def test_recheck_reuses_the_stored_credentials(licensing, keypair, monkeypatch):
         monkeypatch,
         _Response(200, {"license": _document(private_key, deployment, max_users=9)}),
         calls,
+        public_pem=keypair[1],
     )
 
     state = licensing.recheck()
@@ -439,6 +464,146 @@ def test_deactivate_works_even_if_the_server_is_down(licensing, keypair, monkeyp
     monkeypatch.setattr(licensing, "_post", boom)
     licensing.deactivate()
     assert licensing.load_config().document == {}
+
+
+# --- Prüfschlüssel: Übernahme beim ersten Kontakt --------------------------
+
+def test_activation_adopts_the_servers_public_key(licensing, keypair, monkeypatch):
+    """Ohne eingebetteten Schlüssel übernimmt die Installation den des Servers."""
+    private_key, public_pem = keypair
+    monkeypatch.delenv("ERFASSUNG_LICENSE_PUBLIC_KEYS", raising=False)
+    assert licensing.embedded_public_keys() == {}
+
+    document = _document(private_key, licensing.deployment_id())
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}), public_pem=public_pem
+    )
+    state = licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+
+    assert state.is_valid
+    assert licensing.load_config().trusted_keys == {KEY_ID: public_pem}
+    # Und die Offline-Prüfung kommt danach ohne Server aus.
+    assert licensing.current_status().is_valid
+
+
+def test_adopted_key_is_never_silently_replaced(licensing, keypair, monkeypatch):
+    """Ein Serverwechsel mit anderem Schlüssel wird abgewiesen, nicht übernommen."""
+    private_key, public_pem = keypair
+    monkeypatch.delenv("ERFASSUNG_LICENSE_PUBLIC_KEYS", raising=False)
+    document = _document(private_key, licensing.deployment_id())
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}), public_pem=public_pem
+    )
+    licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+
+    # Ein Angreifer gibt sich unter derselben key_id mit eigenem Schlüssel aus.
+    other_private, other_public = _keypair()
+    forged = _document(other_private, licensing.deployment_id(), max_users=9999)
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": forged}), public_pem=other_public
+    )
+    with pytest.raises(licensing.LicenseError) as excinfo:
+        licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+    assert "anderen" in str(excinfo.value)
+
+    # Nichts wurde überschrieben: alte Lizenz, alter Schlüssel.
+    assert licensing.load_config().trusted_keys == {KEY_ID: public_pem}
+    assert licensing.current_status().max_users == 5
+
+
+def test_key_rotation_via_a_new_key_id_is_accepted(licensing, keypair, monkeypatch):
+    """Echte Rotation läuft über eine neue key_id – die wird ergänzt."""
+    private_key, public_pem = keypair
+    monkeypatch.delenv("ERFASSUNG_LICENSE_PUBLIC_KEYS", raising=False)
+    document = _document(private_key, licensing.deployment_id())
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}), public_pem=public_pem
+    )
+    licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+
+    new_private, new_public = _keypair()
+    rotated = _sign(
+        {
+            **{k: v for k, v in document.items() if k != "signature"},
+            "key_id": "k2",
+            "max_users": 50,
+        },
+        new_private,
+    )
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": rotated}),
+        public_pem=new_public, key_id="k2",
+    )
+    state = licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+
+    assert state.max_users == 50
+    trusted = licensing.load_config().trusted_keys
+    assert trusted == {KEY_ID: public_pem, "k2": new_public}
+
+
+def test_embedded_key_wins_over_an_offered_one(licensing, keypair, monkeypatch):
+    """Liefert der Herausgeber einen Schlüssel mit, ist er maßgeblich."""
+    _, public_pem = keypair  # steckt via Fixture in ERFASSUNG_LICENSE_PUBLIC_KEYS
+    other_private, other_public = _keypair()
+    forged = _document(other_private, licensing.deployment_id())
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": forged}), public_pem=other_public
+    )
+    with pytest.raises(licensing.LicenseError):
+        licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+
+
+def test_fingerprint_matches_the_license_server_format(licensing):
+    pem = "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n"
+    value = licensing.fingerprint(pem)
+    assert re.fullmatch(r"SHA256:[0-9A-F]{4}(:[0-9A-F]{4}){3}", value)
+    assert licensing.fingerprint(pem + "\n") == value
+
+
+def test_status_reports_the_fingerprint(licensing, keypair):
+    private_key, public_pem = keypair
+    _store(licensing, _document(private_key, licensing.deployment_id()))
+    state = licensing.current_status()
+    assert state.key_fingerprint == licensing.fingerprint(public_pem)
+
+
+def test_license_page_shows_the_fingerprint(client, licensing, keypair):
+    private_key, public_pem = keypair
+    _store(licensing, _document(private_key, licensing.deployment_id()))
+    _login(client)
+    page = client.get("/admin/system/license")
+    assert licensing.fingerprint(public_pem) in page.text
+
+
+def test_unreachable_key_endpoint_aborts_before_storing(licensing, monkeypatch):
+    import httpx
+
+    def boom(self, url, **kwargs):
+        raise httpx.ConnectError("Name or service not known")
+
+    monkeypatch.setattr(httpx.Client, "get", boom)
+    with pytest.raises(licensing.LicenseError) as excinfo:
+        licensing.activate("https://lizenz.example.invalid", "ERF-TEST-KEY-0001")
+    assert "nicht erreichbar" in str(excinfo.value)
+    assert licensing.load_config().document == {}
+
+
+def test_deactivate_keeps_the_trusted_keys(licensing, keypair, monkeypatch):
+    """Der Prüfschlüssel ist kein Geheimnis – aber sein Wechsel muss auffallen."""
+    private_key, public_pem = keypair
+    monkeypatch.delenv("ERFASSUNG_LICENSE_PUBLIC_KEYS", raising=False)
+    document = _document(private_key, licensing.deployment_id())
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}), public_pem=public_pem
+    )
+    licensing.activate("https://lizenz.example.org", "ERF-TEST-KEY-0001")
+
+    _stub_server(licensing, monkeypatch, _Response(204), public_pem=public_pem)
+    licensing.deactivate()
+
+    config = licensing.load_config()
+    assert config.document == {}
+    assert config.trusted_keys == {KEY_ID: public_pem}
 
 
 # --- Durchsetzung ----------------------------------------------------------
@@ -610,7 +775,10 @@ def test_banner_disappears_with_a_valid_license(client, licensing, keypair):
 def test_activation_via_the_admin_form(client, licensing, keypair, monkeypatch):
     private_key, _ = keypair
     document = _document(private_key, licensing.deployment_id(), max_users=42)
-    _stub_server(licensing, monkeypatch, _Response(200, {"license": document}))
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}),
+        public_pem=keypair[1],
+    )
     _login(client)
     token = _csrf(client, "/admin/system/license")
     response = client.post(
@@ -627,8 +795,8 @@ def test_activation_via_the_admin_form(client, licensing, keypair, monkeypatch):
     assert licensing.current_status().max_users == 42
 
 
-def test_failed_activation_reports_the_reason(client, licensing, monkeypatch):
-    _stub_server(licensing, monkeypatch, _Response(403))
+def test_failed_activation_reports_the_reason(client, licensing, keypair, monkeypatch):
+    _stub_server(licensing, monkeypatch, _Response(403), public_pem=keypair[1])
     _login(client)
     token = _csrf(client, "/admin/system/license")
     response = client.post(
@@ -717,7 +885,10 @@ def test_startup_writes_the_license_status_to_its_own_log(client):
 def test_activation_key_never_reaches_the_log(client, licensing, keypair, monkeypatch):
     private_key, _ = keypair
     document = _document(private_key, licensing.deployment_id())
-    _stub_server(licensing, monkeypatch, _Response(200, {"license": document}))
+    _stub_server(
+        licensing, monkeypatch, _Response(200, {"license": document}),
+        public_pem=keypair[1],
+    )
     _login(client)
     token = _csrf(client, "/admin/system/license")
     client.post(


### PR DESCRIPTION
Der Lizenzserver erzeugt seinen Signierschluessel seit 1.1.0 beim ersten Start selbst. Damit steht der oeffentliche Pruefschluessel erst zur Laufzeit fest und laesst sich nicht mehr sinnvoll ins Image einbetten.

Erfassung holt ihn deshalb bei der Aktivierung ueber GET /v1/instance/public-key und legt ihn in config/license.json ab (Trust on first use, wie SSH beim ersten Verbinden):

* Je key_id ist der Schluessel danach unveraenderlich. Weist sich derselbe Server spaeter mit einem anderen Schluessel fuer dieselbe key_id aus, bricht die Aktivierung mit einer klaren Meldung ab – und es wird nichts ueberschrieben. Ein untergeschobener Lizenzserver kann so keine eigenen Lizenzen einschleusen.
* Eine echte Rotation laeuft ueber eine neue key_id; die wird ergaenzt, der alte Schluessel bleibt erhalten, damit vorhandene Dokumente pruefbar bleiben.
* Ein in app/licensing_keys.py eingebetteter Schluessel hat weiterhin Vorrang und laesst sich vom Server nicht ueberstimmen.
* Der Abruf scheitert, bevor irgendetwas gespeichert wird – eine fehlgeschlagene Aktivierung hinterlaesst keinen halben Zustand.
* Beim Entfernen der Lizenz bleiben die uebernommenen Schluessel erhalten: Sie sind kein Geheimnis, und ein spaeterer Wechsel faellt so weiterhin auf.

Auf der Lizenzseite steht jetzt ein Fingerprint (SHA256:...) im selben Format wie auf der Instanzseite des Lizenzservers – zum Abgleich, ob die Lizenz vom richtigen Server stammt.

9 neue Tests (57 in test_v0110.py, 324 gesamt). README, CHANGELOG und Release Notes entsprechend ergaenzt, inklusive des Restrisikos beim ersten Kontakt.


Claude-Session: https://claude.ai/code/session_01TDoLxffvXWRQpjp3P2RdUw