### PR TITLE
Auftragsbezogenes Stempeln an den Baustein orders binden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ Ab sofort entscheidet ausschließlich das Lizenzdokument.
 
 ### Fixed
 
+- **Auftragsbezogenes Stempeln lief ohne Lizenz weiter.** Firmen- und
+  Auftragsauswahl gehören zum Baustein `orders`, `/punch` war aber bewusst
+  ganz von der Middleware ausgenommen, damit Stempeln nie blockiert. Jetzt
+  entfällt ohne `orders` der ganze Auftragsteil in Dashboard, Mobilansicht und
+  Synchronisation, und `start_company` sowie ein Nachtrag mit Firma werden
+  serverseitig abgewiesen. **„Auftrag beenden" bleibt erlaubt** – läuft eine
+  Lizenz mitten im Auftrag aus, muss sich die Buchung schließen lassen, sonst
+  ginge Arbeitszeit verloren. Das reine Stempeln ist unverändert offen.
 - `GET /api/users/{id}/excel` war nicht lizenzpflichtig, obwohl es eine
   Auswertung ist: Am Pfadpräfix ließ es sich nicht von der Benutzer-API
   unterscheiden, die zur Basis gehört. Die Middleware kennt dafür jetzt
@@ -62,7 +70,7 @@ aktivierte Installation lässt sich also einrichten und aktivieren.
 
 ### Tests
 
-`tests/test_v0121.py` – 27 Tests: jeder zubuchbare Bereich ohne Lizenz zu
+`tests/test_v0121.py` – 33 Tests: jeder zubuchbare Bereich ohne Lizenz zu
 (Oberfläche und API), Basis offen, Navigation ohne die gesperrten Punkte,
 Benutzeranlage abgewiesen, Stempeln und Anmelden weiterhin möglich,
 abgelaufene und ungültige Lizenz schalten nichts frei, gültige Lizenz öffnet

--- a/README.md
+++ b/README.md
@@ -557,6 +557,21 @@ Reiter und Antragsformular der Mobilansicht. Auch `GET /mobile/sync-data`
 liefert dann keine Urlaubsdaten und meldet `request_vacations: false`, damit
 die Offline-Shell einen gesperrten Antrag nicht in die Warteschlange stellt.
 
+Ohne `orders` entfällt der gesamte Auftragsteil: keine Firmenauswahl im
+Dashboard, kein „Auftrag starten" in der Stempel-App, keine Firmenliste in der
+Synchronisation. `start_company` und ein Nachtrag mit Firma werden auch
+serverseitig abgewiesen.
+
+| Aktion | Ohne `orders` |
+|---|---|
+| Arbeitszeit starten/beenden, Pausen, Kommentare | offen |
+| Auftrag starten | abgewiesen |
+| Firma bei einem Nachtrag angeben | abgewiesen |
+| **Auftrag beenden** | **offen** |
+
+„Auftrag beenden" bleibt bewusst offen: Läuft eine Lizenz mitten im Auftrag
+aus, muss sich die laufende Buchung schließen lassen – sonst hinge sie fest.
+
 > **Ohne gültige Lizenz ist kein zubuchbarer Baustein nutzbar** – das gilt für
 > „nicht lizenziert“ genauso wie für „abgelaufen“ und „ungültig“. Freischalten
 > kann nur das Lizenzdokument.

--- a/app/main.py
+++ b/app/main.py
@@ -1655,7 +1655,10 @@ def _build_dashboard_context(db: Session, user: models.User):
     holiday_region = crud.get_default_holiday_region(db)
     holiday_region_label = holiday_calculator.GERMAN_STATES.get(holiday_region, holiday_region)
     holidays = crud.get_holidays_for_year(db, date.today().year, holiday_region)
-    companies = crud.get_companies(db)
+    # Ohne den Baustein „orders" gibt es nichts zum Anstempeln: Ohne Firmenliste
+    # und ohne Anlegeerlaubnis blenden Dashboard und Mobilansicht den ganzen
+    # Auftragsteil von selbst aus (``{% if companies or can_create_companies %}``).
+    companies = crud.get_companies(db) if _can_clock_on_orders() else []
     vacations = crud.get_vacations_for_user(db, user.id)
     daily_overview = _build_daily_overview(db, user.id, today)
     weekly_summary = _build_weekly_overview(db, user, today, today=today)
@@ -1852,6 +1855,12 @@ def submit_time_entry(
         return RedirectResponse(url=redirect, status_code=status.HTTP_303_SEE_OTHER)
     new_company_value = (new_company_name or "").strip()
     company_value: Optional[int] = None
+    if (new_company_value or company_id) and not _can_clock_on_orders():
+        redirect = _build_redirect(
+            _sanitize_next(next_url),
+            error="Auftragsbezogenes Stempeln ist in dieser Lizenz nicht enthalten.",
+        )
+        return RedirectResponse(url=redirect, status_code=status.HTTP_303_SEE_OTHER)
     if new_company_value:
         if not _can_create_companies(user):
             redirect = _build_redirect(
@@ -1977,6 +1986,7 @@ def mobile_sync_data(
     active_entry = crud.get_open_time_entry(db, user.id)
     metrics = services.calculate_dashboard_metrics(db, user.id, today.replace(day=1))
     vacation_licensed = has_license_feature("vacation")
+    orders_licensed = _can_clock_on_orders()
 
     payload = {
         "version": APP_VERSION,
@@ -1993,6 +2003,8 @@ def mobile_sync_data(
             "daily_target_minutes": int(round(user.daily_target_minutes or 0)),
             "weekly_target_minutes": int(round(user.weekly_target_minutes or 0)),
         },
+        # Ohne den Baustein „orders" bekommt die Offline-Shell keine Firmen –
+        # damit bietet sie den Auftragsstart gar nicht erst an.
         "companies": [
             {
                 "id": company.id,
@@ -2000,7 +2012,7 @@ def mobile_sync_data(
                 "description": company.description or "",
             }
             for company in companies
-        ],
+        ] if orders_licensed else [],
         "entries": [_serialize_mobile_entry(entry) for entry in entries],
         "vacations": (
             [_serialize_mobile_vacation(vacation) for vacation in vacations]
@@ -2199,6 +2211,14 @@ def punch_action(
                 message = "Arbeitszeit gestartet."
             elif not error:
                 message = "Arbeitszeit läuft bereits."
+    elif action == "start_company" and not _can_clock_on_orders():
+        # Nur das *Starten* eines Auftrags ist gesperrt. „Auftrag beenden"
+        # bleibt erlaubt, damit ein bereits laufender Auftrag nicht hängen
+        # bleibt, wenn eine Lizenz ausläuft – sonst ginge Arbeitszeit verloren.
+        error = (
+            "Auftragsbezogenes Stempeln ist in dieser Lizenz nicht enthalten. "
+            "Die Arbeitszeit lässt sich weiterhin ohne Auftrag erfassen."
+        )
     elif action == "start_company":
         new_company_value = (new_company_name or "").strip()
         target_company = None
@@ -2713,8 +2733,18 @@ def _can_approve_manual_entries(user: models.User) -> bool:
     return permission_service.has(user, "Time.Approve")
 
 
+def _can_clock_on_orders() -> bool:
+    """Ist auftragsbezogenes Stempeln lizenziert?
+
+    Das reine Stempeln bleibt immer möglich – Firmen und Aufträge gehören
+    dagegen zum Baustein ``orders`` und verschwinden ohne ihn aus Oberfläche,
+    Mobilansicht und Synchronisation.
+    """
+    return has_license_feature("orders")
+
+
 def _can_create_companies(user: models.User) -> bool:
-    return permission_service.has(user, "Company.Create")
+    return permission_service.has(user, "Company.Create") and _can_clock_on_orders()
 
 
 def _can_view_time_reports(user: models.User) -> bool:

--- a/docs/RELEASE_NOTES_0.12.1.md
+++ b/docs/RELEASE_NOTES_0.12.1.md
@@ -85,6 +85,29 @@ dieses Release.
 
 ## Behoben
 
+**Auftragsbezogenes Stempeln lief ohne Lizenz weiter.** Web und Stempel-App
+boten weiterhin an, auf eine Firma bzw. einen Auftrag zu stempeln – obwohl das
+zum Baustein `orders` gehört. Der Grund: `/punch` war bewusst ganz von der
+Middleware ausgenommen, damit eine Lizenzfrage niemals das Stempeln blockiert.
+Genau darin lag die Lücke.
+
+Jetzt gilt fein getrennt:
+
+| Aktion | Ohne `orders` |
+|---|---|
+| Arbeitszeit starten/beenden, Pausen, Kommentare | offen |
+| Auftrag starten (`start_company`) | abgewiesen |
+| Firma bei einem Nachtrag angeben | abgewiesen |
+| **Auftrag beenden** (`end_company`) | **offen** |
+
+Dass „Auftrag beenden" offen bleibt, ist Absicht: Läuft eine Lizenz mitten im
+Auftrag aus, muss sich die laufende Buchung schließen lassen. Sonst hinge sie
+fest und es ginge Arbeitszeit verloren.
+
+Aus der Oberfläche verschwindet der Auftragsteil vollständig – Dashboard,
+Mobilansicht und die Offline-Synchronisation liefern ohne `orders` keine
+Firmenliste und `create_companies: false`.
+
 `GET /api/users/{id}/excel` war nicht lizenzpflichtig. Der Endpunkt ist eine
 Auswertung, ließ sich am Pfadpräfix aber nicht von der Benutzer-API
 unterscheiden, die zur Basis gehört – der Export lief deshalb an der
@@ -101,7 +124,7 @@ Middleware vorbei. Sie kennt jetzt zusätzlich Muster für solche Einzelfälle.
 
 ## Tests
 
-`tests/test_v0121.py` – 27 Tests: jeder zubuchbare Bereich ohne Lizenz zu
+`tests/test_v0121.py` – 33 Tests: jeder zubuchbare Bereich ohne Lizenz zu
 (Oberfläche mit 303 auf das Dashboard, API mit 402), Basis offen, Navigation
 ohne die gesperrten Punkte, Benutzeranlage abgewiesen, Stempeln und Anmelden
 weiterhin möglich, abgelaufene und ungültige Lizenz schalten nichts frei, eine

--- a/tests/test_v0121.py
+++ b/tests/test_v0121.py
@@ -324,6 +324,149 @@ def test_unlicensed_existing_users_keep_working(client):
         db.close()
 
 
+# --- Auftragsbezogenes Stempeln --------------------------------------------
+
+def _company(name: str = "Muster AG") -> int:
+    from app import crud, database, schemas
+
+    db = database.SessionLocal()
+    try:
+        company = crud.create_company(db, schemas.CompanyCreate(name=name, description=""))
+        return int(company.id)
+    finally:
+        db.close()
+
+
+def _open_entry_company(username: str = "admin"):
+    from app import crud, database
+
+    db = database.SessionLocal()
+    try:
+        user = crud.get_user_by_username(db, username)
+        entry = crud.get_open_time_entry(db, user.id)
+        return None if entry is None else entry.company_id
+    finally:
+        db.close()
+
+
+def test_unlicensed_hides_order_clocking(client):
+    """Stempeln ja, auf einen Auftrag stempeln nein."""
+    _company()
+    _login(client)
+    for path in ("/dashboard", "/mobile"):
+        page = client.get(path).text
+        assert "Auftrag starten" not in page, path
+        assert 'value="start_company"' not in page, path
+        # Das reine Stempeln bleibt.
+        assert 'value="start_work"' in page, path
+
+
+def test_unlicensed_refuses_a_company_punch(client):
+    """Auch der direkte Aufruf – die Oberfläche ist nur die halbe Miete."""
+    company_id = _company()
+    _login(client)
+    token = _csrf(client, "/dashboard")
+    response = client.post(
+        "/punch",
+        data={
+            "action": "start_company",
+            "company_id": str(company_id),
+            "csrf_token": token,
+            "next_url": "/dashboard",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    assert "nicht+enthalten" in response.headers["location"]
+    assert _open_entry_company() is None
+
+
+def test_unlicensed_refuses_a_manual_entry_with_a_company(client):
+    company_id = _company()
+    _login(client)
+    token = _csrf(client, "/dashboard")
+    response = client.post(
+        "/time",
+        data={
+            "work_date": "2026-07-01",
+            "start_time": "08:00",
+            "end_time": "16:00",
+            "break_minutes": "30",
+            "company_id": str(company_id),
+            "csrf_token": token,
+            "next_url": "/dashboard",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    assert "nicht+enthalten" in response.headers["location"]
+
+
+def test_unlicensed_sync_payload_omits_companies(client):
+    _company()
+    _login(client)
+    payload = client.get("/mobile/sync-data").json()
+    assert payload["companies"] == []
+    assert payload["permissions"]["create_companies"] is False
+
+
+def test_a_running_order_can_still_be_ended(client, licensing, keypair):
+    """Läuft die Lizenz mitten im Auftrag aus, bleibt „Auftrag beenden" offen.
+
+    Sonst hinge die Buchung fest und es ginge Arbeitszeit verloren.
+    """
+    company_id = _company()
+    _store(licensing, _document(keypair[0], licensing.deployment_id(), features=["orders"]))
+    _login(client)
+    token = _csrf(client, "/dashboard")
+    client.post(
+        "/punch",
+        data={
+            "action": "start_company",
+            "company_id": str(company_id),
+            "csrf_token": token,
+            "next_url": "/dashboard",
+        },
+        follow_redirects=False,
+    )
+    assert _open_entry_company() == company_id
+
+    # Lizenz weg – der laufende Auftrag muss sich beenden lassen.
+    _store(licensing, _document(keypair[0], licensing.deployment_id(), features=[]))
+    response = client.post(
+        "/punch",
+        data={"action": "end_company", "csrf_token": token, "next_url": "/dashboard"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    assert "error=" not in response.headers["location"]
+    assert _open_entry_company() is None
+
+
+def test_licensed_orders_allow_clocking_on_a_company(client, licensing, keypair):
+    company_id = _company()
+    _store(licensing, _document(keypair[0], licensing.deployment_id(), features=["orders"]))
+    _login(client)
+    assert "Auftrag starten" in client.get("/dashboard").text
+    payload = client.get("/mobile/sync-data").json()
+    assert company_id in [company["id"] for company in payload["companies"]]
+
+    token = _csrf(client, "/dashboard")
+    response = client.post(
+        "/punch",
+        data={
+            "action": "start_company",
+            "company_id": str(company_id),
+            "csrf_token": token,
+            "next_url": "/dashboard",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    assert "error=" not in response.headers["location"]
+    assert _open_entry_company() == company_id
+
+
 # --- Ungültig, abgelaufen, gesperrt ----------------------------------------
 
 def test_an_expired_license_closes_the_modules(client, licensing, keypair):


### PR DESCRIPTION
Web und Stempel-App boten weiterhin an, auf eine Firma bzw. einen Auftrag zu stempeln, obwohl das zu orders gehoert. /punch war bewusst ganz von der Middleware ausgenommen, damit eine Lizenzfrage niemals das Stempeln blockiert - darin lag die Luecke.

Ohne orders:
- keine Firmenliste und kein "Auftrag starten" in Dashboard, Mobilansicht und /mobile/sync-data (companies: [], create_companies: false)
- start_company und ein Nachtrag ueber /time mit Firma werden serverseitig abgewiesen
- end_company bleibt erlaubt: Laeuft eine Lizenz mitten im Auftrag aus, muss sich die laufende Buchung schliessen lassen, sonst haengt sie fest und es geht Arbeitszeit verloren
- reines Stempeln, Pausen und Kommentare bleiben unveraendert offen

Tests: 418 gruen, davon 33 in tests/test_v0121.py.


Claude-Session: https://claude.ai/code/session_01TDoLxffvXWRQpjp3P2RdUw