### PR TITLE
0.20.7 Nachzügler: Rücknahmeanfragen entscheidbar, deutsche Monatsüberschriften

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ Fehler an vier weiteren Stellen zum Vorschein kam. Einzelheiten in
 - Die Fußnote der Benutzerauswertung beschrieb noch die Rechnung
   „Arbeitstage (Mo–Fr) × Tagessoll"; gerechnet wird seit 0.20.3 über den
   Arbeitszeitplan.
+- **Rücknahmeanfragen ließen sich nicht entscheiden.** Die Schaltflächen
+  „Rücknahme bestätigen" und „Ablehnen" unter Administration → Freigaben saßen
+  als einzige der Seite in einem Formular **ohne CSRF-Token**. Da die Prüfung
+  für jede zustandsändernde Anfrage greift, endete jeder Klick auf
+  „403 – Ungültige Sitzung", und ein zurückgezogener Urlaub blieb dauerhaft in
+  „Rücknahme angefragt" hängen – die Tage waren zurückgegeben, die Abwesenheit
+  stand weiter im Kalender. Ein Test prüft jetzt **jedes** POST-Formular aller
+  Vorlagen auf ein Token.
+- Über der Buchungsseite und in der Monatszusammenfassung des Dashboards stand
+  noch „06/2026" statt „Juni 2026"; die deutschen Monatsnamen aus 0.20.1 hatten
+  diese beiden Überschriften nicht erreicht.
 
 ### Datenbankänderungen
 Keine. Die Schemaversion bleibt bei 23.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Erfassung ist eine FastAPI-basierte Zeiterfassungsanwendung (Web-App) mit Benutz
 > Teamkalender" stehen auf jeder Seite des Bereichs, der Teamkalender nennt
 > seinen Umfang und zeigt offene Anträge (die Art der Abwesenheit bleibt
 > verdeckt), und im Benutzerformular steht der QR-Code oben rechts, die
-> Arbeitszeitpläne darunter. Kein Schemawechsel. Details in
+> Arbeitszeitpläne darunter. Ein Anwenderdurchlauf durch die gesamte Anwendung
+> (239 Einzelprüfungen) hat außerdem zutage gebracht, dass sich
+> **Rücknahmeanfragen gar nicht entscheiden ließen**: Ihr Formular trug als
+> einziges der Freigabenseite kein CSRF-Token, jeder Klick endete auf
+> „403 – Ungültige Sitzung". Kein Schemawechsel. Details in
 > [`docs/RELEASE_NOTES_0.20.7.md`](docs/RELEASE_NOTES_0.20.7.md).
 
 > Seit 0.20.6: **korrigierter Abwesenheitskalender und Benutzerverwaltung** – der Monatswechsel lädt sofort, die Wochenansicht folgt der Monatswahl und Arbeitszeitpläne werden in einem responsiven Dialog verwaltet.
@@ -1342,7 +1346,7 @@ Eine Lizenz schaltet Bereiche frei. **Immer enthalten** und nie gesperrt:
 - Sicherung und Wiederherstellung
 - Systemeinstellungen, Logs, Datenbankverwaltung
 
-Zubuchbar sind vier Bausteine:
+Zubuchbar sind fünf Bausteine:
 
 | Baustein | Schaltet frei |
 |---|---|
@@ -1351,6 +1355,18 @@ Zubuchbar sind vier Bausteine:
 | `reports` | PDF-/Excel-Exporte, Benutzer- und Team-Auswertungen |
 | `terminals` | RFID-Terminals und Geräte-Synchronisation |
 | `calendar_sync` | widerrufbare persönliche und Team-iCalendar-Feeds |
+
+`calendar_sync` setzt `vacation` voraus: Ohne den Urlaubsbaustein gibt es
+nichts zu synchronisieren, und der Baustein bleibt wirkungslos, selbst wenn er
+im Lizenzdokument steht.
+
+> **Serverseitig zu ergänzen.** Die Anwendung kennt `calendar_sync` seit
+> 0.20.3 und setzt ihn vollständig durch. Freigeschaltet wird er aber nur,
+> wenn der **Lizenzserver** ihn in der Liste `features` des signierten
+> Lizenzdokuments ausliefert. Solange das nicht geschieht, ist die Karte
+> „Kalender abonnieren" für alle Installationen unsichtbar und der
+> ICS-Endpunkt gesperrt – ohne Fehlermeldung, wie es sich für einen nicht
+> gebuchten Baustein gehört.
 
 Eine Lizenz ohne jeden Baustein ist damit eine reine **Stempel-Lizenz** – und
 genau so viel kann eine Installation ohne Lizenz auch.

--- a/docs/RELEASE_NOTES_0.20.7.md
+++ b/docs/RELEASE_NOTES_0.20.7.md
@@ -98,7 +98,33 @@ Momentaufnahme (`/mobile/sync-data`). Die beiden Pauschalwerte bleiben im
 Baustein `user` erhalten; eine Momentaufnahme, die vor dem Update entstanden
 ist, rechnet damit weiter wie bisher.
 
-## 6. Weitere Befunde aus der Durchsicht der Anzeigen
+## 6. Rücknahmeanfragen ließen sich nicht entscheiden
+
+Unter Administration → **Freigaben** gibt es den Abschnitt
+*Rücknahmeanfragen*. Seine beiden Schaltflächen – **Rücknahme bestätigen** und
+**Ablehnen** – saßen in einem Formular **ohne CSRF-Token**, als einzigem der
+Seite. Die CSRF-Prüfung läuft für jede zustandsändernde Anfrage; jeder Klick
+endete deshalb auf „403 – Ungültige Sitzung", und der Antrag behielt seinen
+Status.
+
+Praktisch hieß das: Zieht jemand einen bereits genehmigten Urlaub zurück,
+blieb der Antrag dauerhaft in *Rücknahme angefragt* hängen. Er zählte in
+diesem Zustand nicht mehr als verbrauchter Urlaub – die Tage waren also
+zurückgegeben –, während die Abwesenheit im Kalender weiter stand. Über die
+Oberfläche ließ sich das nicht auflösen.
+
+Behoben durch das fehlende Feld. Zwei Tests sichern das ab: einer prüft **jedes**
+POST-Formular aller Vorlagen auf ein Token, ein zweiter spielt den ganzen
+Vorgang durch. Ein dritter stellt sicher, dass ein Aufruf **ohne** Token
+weiterhin mit 403 abgewiesen wird – die Reparatur darf die Prüfung nicht
+aufweichen.
+
+Der zweite Fund derselben Suche war ein Fehlalarm: Im Standortformular
+(`templates/admin/company_form.html`) steht das Token außerhalb der
+`<form>`-Marken und wird über das HTML-Attribut `form="…"` zugeordnet. Der
+Test kennt dieses Muster.
+
+## 7. Weitere Befunde aus der Durchsicht der Anzeigen
 
 - **Benutzerformular, Feld „Wochenarbeitszeit".** Es zeigte 40 Stunden,
   während die Anwendung mit einem Plan über 32 Stunden rechnete – zwei Zahlen,
@@ -106,10 +132,59 @@ ist, rechnet damit weiter wie bisher.
   darunter, welcher gilt und mit wie vielen Wochenstunden.
 - **Auswertung „Benutzerauswertung", Fußnote.** Sie beschrieb noch die Rechnung
   „Arbeitstage (Mo–Fr) × Tagessoll"; gerechnet wird seit 0.20.3 über den Plan.
+- **Monatsüberschriften auf Deutsch.** Über der Buchungsseite und in der
+  Monatszusammenfassung des Dashboards stand noch „06/2026"; die deutschen
+  Monatsnamen aus 0.20.1 hatten diese beiden Stellen nicht erreicht. Jetzt
+  „Juni 2026", wie im Kalender und in der Regelübersicht.
 - **Alle Template-Variablen geprüft.** Ein Durchlauf über sämtliche Vorlagen
   hat keine Variable gefunden, die keine Route liefert – Jinja rendert
   Unbekanntes stillschweigend als leer, genau so entsteht eine Anzeige ohne
   Wert.
+
+---
+
+## Anwenderdurchlauf durch die gesamte Anwendung
+
+Zusätzlich zur Testsuite wurde die Anwendung über HTTP wie von Hand bedient –
+fünf Abschnitte, 239 Einzelprüfungen. Jede angezeigte Zahl wurde dabei
+**unabhängig nachgerechnet**, nicht mit den Funktionen der Anwendung selbst.
+
+| Abschnitt | Umfang | Ergebnis |
+| --- | --- | --- |
+| Stempeln, Pausen, Dauern | Anmeldung, Kennwortzwang, Start/Pause/Ende, Einsatzort, §-4-Grenzen, Zeitumstellung, Storno | 26 von 26 |
+| Übersichten und Berechnungen | Tages-, Wochen- und Monatswerte, Urlaubskonto, Feiertagsgutschrift, Arbeitszeitplan | 44 von 44 |
+| Urlaub, Freigaben, Kalender | Antrag, halber Tag, Genehmigung, Ablehnung, Rücknahme, alle Kalenderansichten, iCalendar-Feed | 41 von 41 |
+| Administration und Auswertungen | 32 Verwaltungsseiten, Stammdatenpflege, Buchung bearbeiten, Historie, PDF- und Excel-Export | 68 von 68 |
+| Rechte, System, App | 22 gesperrte Seiten für ein Konto ohne Rechte, API, CSRF, Sicherung, Offline-Shell | 60 von 60 |
+
+Einzelne Ergebnisse, die dabei bestätigt wurden:
+
+- **§ 4 ArbZG an den Grenzen.** Glatt sechs Stunden verlangen keine Pause,
+  6:01 verlangt 30 Minuten; glatt neun Stunden 30, 9:01 dann 45. Eine nicht
+  genommene Pause wird gekennzeichnet, aber nicht abgezogen – die
+  Arbeitszeit bleibt so, wie sie war.
+- **Unterbrechungen unter 15 Minuten** werden von der Arbeitszeit abgezogen,
+  erfüllen die Pausenpflicht aber nicht.
+- **Zeitumstellung.** Eine Schicht von 00:00 bis 06:00 am 29. März 2026 dauert
+  fünf Stunden, nicht sechs.
+- **Stornierte Buchungen** behalten ihre Zeiten und zählen null Minuten.
+- **Der iCalendar-Feed** enthält keine Kommentare, ein falsches Token liefert
+  404, und nach dem Widerruf liefert der Feed nichts mehr.
+- **Geltungsbereiche.** Ein Konto ohne Verwaltungsrechte kommt an keine der
+  22 geprüften Verwaltungsseiten, an kein fremdes Konto, an keine fremde
+  Buchung und an keinen Auskunftsexport.
+
+### Zum Lizenzbaustein Kalendersynchronisation
+
+Die Durchsetzung von `calendar_sync` wurde in vier Lizenzzuständen geprüft
+(ohne Urlaubsbaustein; mit Urlaub ohne `calendar_sync`; mit beiden; sowie
+`calendar_sync` ohne Urlaub). In **jedem** unlizenzierten Fall wurde kein
+Feed angelegt, und der ICS-Endpunkt bleibt gesperrt. `calendar_sync` setzt
+`vacation` voraus; ohne den Urlaubsbaustein bleibt er wirkungslos.
+
+Die Anwendung ist damit vollständig vorbereitet. Was noch fehlt, liegt
+**außerhalb dieses Repositorys**: Der Lizenzserver muss `calendar_sync` in der
+Liste `features` des signierten Lizenzdokuments ausliefern.
 
 ---
 

--- a/templates/admin/approvals.html
+++ b/templates/admin/approvals.html
@@ -127,7 +127,13 @@
                         <td>{% if vacation.use_overtime %}{{ vacation.overtime_minutes|format_minutes }} Std{% else %}–{% endif %}</td>
                         <td>{{ vacation.comment or '-' }}</td>
                         <td class="actions">
+                            {# Ohne dieses Feld beantwortet die CSRF-Prüfung jeden Klick
+                               mit „403 – Ungültige Sitzung": Sie greift für jede
+                               zustandsändernde Anfrage. Bis 0.20.7 fehlte es hier als
+                               einzigem Formular der Seite, womit sich eine
+                               Rücknahmeanfrage überhaupt nicht entscheiden ließ. #}
                             <form method="post" action="/admin/vacations/{{ vacation.id }}/status" class="inline-form">
+                                <input type="hidden" name="csrf_token" value="{{ get_csrf_token(request) }}">
                                 <button type="submit" name="action" value="approve_withdraw" class="button small">Rücknahme bestätigen</button>
                                 <button type="submit" name="action" value="deny_withdraw" class="button danger small">Ablehnen</button>
                             </form>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -320,7 +320,7 @@
             <div class="dashboard-metrics-card__section dashboard-metrics-card__section--hours">
                 <header class="dashboard-summary-card__header">
                     <h2>Meine Soll-/Ist-Stunden</h2>
-                    <p class="dashboard-summary__month">Übersicht für {{ metrics_month.strftime('%m/%Y') }}</p>
+                    <p class="dashboard-summary__month">Übersicht für {{ metrics_month|month_name }} {{ metrics_month.year }}</p>
                 </header>
                 <div class="dashboard-summary-card__body">
                     <dl class="dashboard-summary-list">

--- a/templates/records/bookings.html
+++ b/templates/records/bookings.html
@@ -5,7 +5,10 @@
 {% include "records/_nav.html" %}
 <section class="card records-hero">
     <div class="card-header">
-        <h1>Arbeitszeitübersicht – {{ selected_month.strftime('%m/%Y') }}</h1>
+        {# Ausgeschriebener Monat wie im Kalender und in der Regelübersicht.
+           Bis 0.20.7 stand hier „06/2026"; die deutschen Monatsnamen aus
+           0.20.1 hatten diese beiden Überschriften nicht erreicht. #}
+        <h1>Arbeitszeitübersicht – {{ selected_month|month_name }} {{ selected_month.year }}</h1>
         <div class="card-header__actions">
             <a class="button ghost" href="/records/pdf?month={{ month_value }}">PDF-Export</a>
             <a class="button" href="/api/users/{{ user.id }}/excel">Excel-Export</a>

--- a/tests/test_v0207.py
+++ b/tests/test_v0207.py
@@ -603,3 +603,110 @@ def test_monthly_and_weekly_targets_agree(main):
     # Vier volle Wochen ab dem 1. Juni decken den 1.–28. Juni ab; der 29. und
     # 30. Juni sind Montag und Dienstag und tragen je 480 Minuten bei.
     assert monthly == weekly + 2 * 480
+
+
+# ── 8. Befunde aus dem Anwenderdurchlauf ──────────────────────────────────
+
+
+def test_every_post_form_carries_a_csrf_token():
+    """Die CSRF-Prüfung greift für jede zustandsändernde Anfrage.
+
+    Ein Formular ohne Token ist deshalb eine Schaltfläche, die nichts tut
+    außer „403 – Ungültige Sitzung" anzuzeigen. Bis 0.20.7 fehlte das Feld im
+    Abschnitt „Rücknahmeanfragen" – eine Rücknahme ließ sich überhaupt nicht
+    entscheiden.
+
+    Felder dürfen dem Formular auch über das HTML-Attribut ``form="…"`` von
+    außerhalb zugeordnet sein; dann steht das Token nicht zwischen den Tags.
+    """
+    form_open = re.compile(r"<form\b[^>]*>", re.IGNORECASE)
+    offenders = []
+    for path in sorted((ROOT / "templates").rglob("*.html")):
+        text = path.read_text(encoding="utf-8")
+        for match in form_open.finditer(text):
+            tag = match.group(0)
+            if 'method="post"' not in tag.lower():
+                continue
+            end = text.find("</form>", match.end())
+            body = text[match.end():end if end != -1 else len(text)]
+            if "csrf_token" in body:
+                continue
+            form_id = re.search(r'id="([^"]+)"', tag)
+            if form_id and f'form="{form_id.group(1)}"' in text:
+                continue  # Felder hängen über das form-Attribut daran
+            line = text[: match.start()].count("\n") + 1
+            offenders.append(f"{path.relative_to(ROOT)}:{line}")
+    assert not offenders, "POST-Formulare ohne CSRF-Token: " + ", ".join(offenders)
+
+
+def test_withdrawal_can_actually_be_decided(client):
+    """Der ganze Vorgang: beantragen, zurückziehen, Rücknahme freigeben."""
+    from app import models
+
+    _login(client)
+    admin_id = _admin_id()
+    start = date(2026, 10, 5)
+    with _db() as db:
+        row = models.VacationRequest(
+            user_id=admin_id, start_date=start, end_date=start + timedelta(days=4),
+            status=models.VacationStatus.WITHDRAW_REQUESTED,
+            previous_status="approved", absence_type_key="vacation",
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        vacation_id = row.id
+
+    page = client.get("/admin/approvals").text
+    section = page.split("Rücknahmeanfragen", 1)[1]
+    form = section[section.index("<form"):section.index("</form>")]
+    assert "csrf_token" in form, "Das Formular der Rücknahmeanfragen braucht ein Token"
+
+    response = client.post(
+        f"/admin/vacations/{vacation_id}/status",
+        data={"action": "approve_withdraw", "csrf_token": _csrf(client, "/dashboard")},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    with _db() as db:
+        after = db.query(models.VacationRequest).filter(
+            models.VacationRequest.id == vacation_id
+        ).first().status
+    assert after == models.VacationStatus.CANCELLED
+
+
+def test_a_withdrawal_without_a_token_is_still_rejected(client):
+    """Die Reparatur darf die Prüfung nicht aufweichen."""
+    from app import models
+
+    _login(client)
+    start = date(2026, 11, 2)
+    with _db() as db:
+        row = models.VacationRequest(
+            user_id=_admin_id(), start_date=start, end_date=start,
+            status=models.VacationStatus.WITHDRAW_REQUESTED,
+            previous_status="approved", absence_type_key="vacation",
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        vacation_id = row.id
+    response = client.post(
+        f"/admin/vacations/{vacation_id}/status",
+        data={"action": "approve_withdraw"}, follow_redirects=False,
+    )
+    assert response.status_code == 403
+
+
+def test_month_headings_are_german(client):
+    """Bis 0.20.6 stand über der Buchungsseite „06/2026"."""
+    _login(client)
+    body = client.get("/records?month=2026-06").text
+    assert "Juni 2026" in body
+    assert "06/2026" not in body
+
+
+def test_no_numeric_month_format_remains():
+    for name in ("records/bookings.html", "dashboard.html"):
+        source = (ROOT / "templates" / name).read_text(encoding="utf-8")
+        assert "'%m/%Y'" not in source, name


### PR DESCRIPTION
> **Warum es diesen PR gibt.** PR #172 wurde gemergt, als der Branch erst den ersten 0.20.7-Commit enthielt. Der zweite Commit kam kurz danach – er ist nie in `main` angekommen. Dieser PR holt genau das nach, ein Commit (`5700bbe`), sonst nichts.

## Rücknahmeanfragen ließen sich nicht entscheiden

Unter **Administration → Freigaben** gibt es den Abschnitt *Rücknahmeanfragen*. Seine beiden Schaltflächen – **Rücknahme bestätigen** und **Ablehnen** – saßen in einem Formular **ohne CSRF-Token**, als einzigem der Seite. Die CSRF-Prüfung greift für jede zustandsändernde Anfrage; jeder Klick endete auf `403 – Ungültige Sitzung`, und der Antrag behielt seinen Status.

**Was das im Betrieb bedeutet.** Zieht jemand einen bereits genehmigten Urlaub zurück, blieb der Antrag dauerhaft in *Rücknahme angefragt* hängen. In diesem Zustand zählte er **nicht mehr** als verbrauchter Urlaub – die Tage waren also zurückgegeben –, während die Abwesenheit im Kalender weiter stand. Über die Oberfläche ließ sich das nicht auflösen.

Nachgestellt und bestätigt:

```
Enthaelt das Formular ein CSRF-Token? False
Klick auf 'Ruecknahme bestaetigen' -> HTTP 403
   403 – Ungültige Sitzung
Status des Antrags danach: 'withdraw_requested'

Derselbe Aufruf mit Token -> HTTP 303, Status danach: 'cancelled'
```

Behoben durch das fehlende Feld. Drei Tests sichern das ab: einer prüft **jedes** POST-Formular aller Vorlagen auf ein Token, einer spielt den ganzen Vorgang durch, einer stellt sicher, dass ein Aufruf **ohne** Token weiterhin mit 403 abgewiesen wird – die Reparatur darf die Prüfung nicht aufweichen.

Der zweite Treffer derselben Suche war ein Fehlalarm: Im Standortformular (`templates/admin/company_form.html`) steht das Token außerhalb der `<form>`-Marken und wird über das HTML-Attribut `form="…"` zugeordnet. Der Test kennt dieses Muster.

## Deutsche Monatsüberschriften

Über der Buchungsseite und in der Monatszusammenfassung des Dashboards stand noch `06/2026`. Die deutschen Monatsnamen aus 0.20.1 hatten diese beiden Stellen nicht erreicht – jetzt „Juni 2026", wie im Kalender und in der Regelübersicht.

## Herkunft

Beide Befunde stammen aus einem Anwenderdurchlauf durch die gesamte Anwendung – fünf Abschnitte, 239 Einzelprüfungen, jede angezeigte Zahl unabhängig nachgerechnet. Die Einzelheiten stehen in `docs/RELEASE_NOTES_0.20.7.md`, das dieser PR entsprechend ergänzt.

## Prüfungen

Volle Testsuite zum Zeitpunkt dieses Commits: **841 bestanden, 0 fehlgeschlagen**. Kein Schemawechsel, keine Migration.

## Zusammenhang

PR #173 (Version 0.20.8) baut auf diesem Branch auf. Nach dem Merge hier stellt GitHub #173 automatisch auf `main` um.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDoLxffvXWRQpjp3P2RdUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDoLxffvXWRQpjp3P2RdUw)_